### PR TITLE
Improve Common

### DIFF
--- a/src/main/java/org/mineacademy/fo/Common.java
+++ b/src/main/java/org/mineacademy/fo/Common.java
@@ -700,7 +700,7 @@ public final class Common {
 	 * @return
 	 */
 	public static String chatLineSmooth() {
-		return ChatColor.STRIKETHROUGH + "――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――";
+		return ChatColor.STRIKETHROUGH + "                                                                ";
 	}
 
 	/**

--- a/src/main/java/org/mineacademy/fo/Common.java
+++ b/src/main/java/org/mineacademy/fo/Common.java
@@ -703,6 +703,21 @@ public final class Common {
 		return ChatColor.STRIKETHROUGH + "                                                                ";
 	}
 
+	public static final String emptyLine() {
+		return "\n ";
+	}
+
+	/**
+	 * Creates a long -------- chat line using {@link #chatLineSmooth()}
+	 * @param addEmptyLine Whether an empty line should be added.
+	 * @param below If true, the empty line will be added below the chatLine,
+	 *              false it will be added above.
+	 * @return Returns a long chat line with an empty line either above or below the chatline.
+	 */
+	public static String chatLineSmooth(boolean addEmptyLine, boolean below) {
+		return addEmptyLine ? below ? chatLineSmooth() + emptyLine() : emptyLine() + chatLineSmooth() : chatLineSmooth();
+	}
+
 	/**
 	 * Returns a very long -------- config line
 	 *


### PR DESCRIPTION
Update Common#chatLineSmooth to use strikethrough whitespace instead of "&m---".
Adds a new Common#emptyLine which returns a regex "\n " with whitespace - a new empty line.
Adds a new Comon#chatLineSmooth(boolean, boolean) which adds a line of whitespace either before or after the chatLine.