### PR TITLE
Prevent MOST occurrences of mouse position reset when opening a new menu

### DIFF
--- a/src/main/java/org/mineacademy/fo/menu/model/InventoryDrawer.java
+++ b/src/main/java/org/mineacademy/fo/menu/model/InventoryDrawer.java
@@ -134,8 +134,11 @@ public final class InventoryDrawer {
 
 		inv.setContents(content);
 
-		// Before opening make sure we close his old inventory if exist
-		if (player.getOpenInventory() != null)
+		// Before opening make sure we close his old inventory if exist,
+		// but only if the inventory is NOT a menu. If it is a menu, we can overwrite the contents,
+		// as they will be re-rendered upon calling Menu#displayTo again. This will prevent the annoying
+		// mouse position reset that happens when you move from inventory to inventory.
+		if (player.getOpenInventory() != null && !player.hasMetadata("Ka_Menu"))
 			player.closeInventory();
 
 		player.openInventory(inv);


### PR DESCRIPTION
Essentially this will overwrite other MENUS when opening a new Menu, allowing for a smoother experience. This will make menus made with this plugin more professional and less clunky.

What do you think @kangarko @JavaFactoryDev ?