### PR TITLE
Improve ReflectionUtil

### DIFF
--- a/src/main/java/org/mineacademy/fo/ReflectionUtil.java
+++ b/src/main/java/org/mineacademy/fo/ReflectionUtil.java
@@ -201,6 +201,13 @@ public final class ReflectionUtil {
 			return field;
 		}
 
+		public void clearCache() {
+			while (!caching.isEmpty()); // Wait for existing values to continue caching
+			methodCache.clear();
+			reflectionDataCache.clear();
+			constructorCache.clear();
+		}
+
 	}
 
 	/**
@@ -213,9 +220,24 @@ public final class ReflectionUtil {
 	 */
 	public static final String CRAFTBUKKIT = "org.bukkit.craftbukkit";
 
-	public static void clearCachedData(final Class<?> clazz) {
-		classCache.remove(clazz.getCanonicalName());
-		reflectionDataCache.remove(clazz);
+	public static void clearCachedData(final Class<?>... classes) {
+		if (classes == null) {
+			return;
+		}
+		for (final Class<?> clazz : classes) {
+			classCache.remove(clazz.getCanonicalName());
+			final ReflectionData<?> data = reflectionDataCache.get(clazz);
+			if (data != null) {
+				data.clearCache();
+			}
+			reflectionDataCache.remove(clazz);
+		}
+	}
+
+	public static void clearCachedData() {
+		classCache.clear();
+		reflectionDataCache.values().forEach(ReflectionData::clearCache);
+		reflectionDataCache.clear();
 	}
 
 	/**

--- a/src/main/java/org/mineacademy/fo/ReflectionUtil.java
+++ b/src/main/java/org/mineacademy/fo/ReflectionUtil.java
@@ -345,7 +345,7 @@ public final class ReflectionUtil {
 
 	/**
 	 * Return a constructor for the given OBC class. We prepend the class name
-	 * with the {@link #OBC} so you only have to give in the name of the class.
+	 * with the {@link #CRAFTBUKKIT} so you only have to give in the name of the class.
 	 *
 	 * @param obcClass
 	 * @param params
@@ -357,7 +357,7 @@ public final class ReflectionUtil {
 
 	/**
 	 * Return a constructor for the given OBC class. We prepend the class name
-	 * with the {@link #OBC} so you only have to give in the name of the class.
+	 * with {@link #CRAFTBUKKIT} so you only have to give in the name of the class.
 	 *
 	 * @param cache Whether the returned value should be cached for later use.
 	 */
@@ -440,7 +440,6 @@ public final class ReflectionUtil {
 	 * @param clazz
 	 * @param field
 	 * @param instance
-	 * @param type
 	 * @return
 	 */
 	public static <T> T getFieldContent(Class<?> clazz, final String field, final Object instance) {
@@ -689,7 +688,7 @@ public final class ReflectionUtil {
 	 * Invoke a static method
 	 *
 	 * @param <T>
-	 * @param method
+	 * @param methodName
 	 * @param params
 	 * @return
 	 */
@@ -718,7 +717,7 @@ public final class ReflectionUtil {
 	 * Invoke a non static method
 	 *
 	 * @param <T>
-	 * @param method
+	 * @param methodName
 	 * @param instance
 	 * @param params
 	 * @return
@@ -1110,7 +1109,7 @@ public final class ReflectionUtil {
 	public static String getCallerMethods(final int skipMethods, final int count) {
 		final StackTraceElement[] elements = Thread.currentThread().getStackTrace();
 
-		String methods = "";
+		final StringBuilder methods = new StringBuilder();
 		int counted = 0;
 
 		for (int i = 2 + skipMethods; i < elements.length && counted < count; i++) {
@@ -1119,12 +1118,12 @@ public final class ReflectionUtil {
 			if (!el.getMethodName().equals("getCallerMethods") && el.getClassName().indexOf("java.lang.Thread") != 0) {
 				final String[] clazz = el.getClassName().split("\\.");
 
-				methods += clazz[clazz.length == 0 ? 0 : clazz.length - 1] + "#" + el.getLineNumber() + "-" + el.getMethodName() + "()" + (i + 1 == elements.length ? "" : ".");
+				methods.append(clazz[clazz.length == 0 ? 0 : clazz.length - 1]).append("#").append(el.getLineNumber()).append("-").append(el.getMethodName()).append("()").append(i + 1 == elements.length ? "" : ".");
 				counted++;
 			}
 		}
 
-		return methods;
+		return methods.toString();
 	}
 
 	/**

--- a/src/main/java/org/mineacademy/fo/ReflectionUtil.java
+++ b/src/main/java/org/mineacademy/fo/ReflectionUtil.java
@@ -657,6 +657,19 @@ public final class ReflectionUtil {
 		return null;
 	}
 
+	/**
+	 * Get a declared class method
+	 *
+	 */
+	public static Method getDeclaredMethod(final Class<?> clazz, final String methodName, Class<?>... args) {
+		return getDeclaredMethod(false, clazz, methodName, args);
+	}
+
+	/**
+	 * Get a declared class method
+	 *
+	 * @param cache Whether or not the looked-up method should be cached.
+	 */
 	public static Method getDeclaredMethod(boolean cache, final Class<?> clazz, final String methodName, Class<?>... args) {
 		try {
 			if (reflectionDataCache.containsKey(clazz)) {
@@ -788,12 +801,17 @@ public final class ReflectionUtil {
 				classes.add(paramClass.isPrimitive() ? ClassUtils.wrapperToPrimitive(paramClass) : paramClass);
 			}
 
+			Class<?>[] paramArr = classes.toArray(new Class<?>[0]);
 			final Constructor<T> c;
-			if (cache) {
-				classCache.put(clazz.getCanonicalName(), clazz);
-				c = (Constructor<T>) reflectionDataCache.computeIfAbsent(clazz, ReflectionData::new).getDeclaredConstructor(true, classes.toArray(new Class<?>[0]));
+			if (reflectionDataCache.containsKey(clazz)) {
+				c = ((ReflectionData<T>) reflectionDataCache.get(clazz)).getDeclaredConstructor(cache, paramArr);
 			} else {
-				c = clazz.getDeclaredConstructor(classes.toArray(new Class<?>[0]));
+				if (cache) {
+					classCache.put(clazz.getCanonicalName(), clazz);
+					c = (Constructor<T>) reflectionDataCache.computeIfAbsent(clazz, ReflectionData::new).getDeclaredConstructor(true, paramArr);
+				} else {
+					c = clazz.getDeclaredConstructor(paramArr);
+				}
 			}
 			c.setAccessible(true);
 

--- a/src/main/java/org/mineacademy/fo/ReflectionUtil.java
+++ b/src/main/java/org/mineacademy/fo/ReflectionUtil.java
@@ -657,6 +657,21 @@ public final class ReflectionUtil {
 		return null;
 	}
 
+	public static Method getDeclaredMethod(boolean cache, final Class<?> clazz, final String methodName, Class<?>... args) {
+		try {
+			if (reflectionDataCache.containsKey(clazz)) {
+				return reflectionDataCache.get(clazz).getDeclaredMethod(methodName, cache, args);
+			}
+			if (cache) {
+				return reflectionDataCache.computeIfAbsent(clazz, ReflectionData::new).getDeclaredMethod(methodName, true, args); // Cache the value.
+			}
+			return clazz.getDeclaredMethod(methodName, args);
+		} catch (ReflectiveOperationException ex) {
+			ex.printStackTrace();
+		}
+		return null;
+	}
+
 	/**
 	 * Invoke a static method
 	 *


### PR DESCRIPTION
Hi, this PR intends to add the ability to cache classes, methods, constructors and fields into ReflectionUtil. Hopefully this can improve performance for recursive method lookups. Currently:

- A new static inner class in ReflectionUtil - `ReflectionData<T>` has been added which hold 3 Maps, one for constructors, one for methods and one for fields.
- ReflectionData should be thread-safe (there are mutation guards), however, I have not added a guard for static classCache and reflectionDataCache in ReflectionUtil. Not really sure if one is warranted, however, it may make sense to add one (would like some feedback on this!)
- Changes to existing methods to used cached values where possible.
- Method overrides for reflective lookups with a param cache which indicates whether the looked-up value(s) should be cached.

This PR is untested. There are no breaking changes in the code (method invoker decides whether the constructor, field etc should be cached); However, I'm not entirely sure if there will be a noticeable improvement in performance.