### PR TITLE
Add the ability to force-load on new versions

### DIFF
--- a/src/main/java/org/mineacademy/fo/plugin/SimplePlugin.java
+++ b/src/main/java/org/mineacademy/fo/plugin/SimplePlugin.java
@@ -180,6 +180,13 @@ public abstract class SimplePlugin extends JavaPlugin implements Listener {
 	 * block. We register things using {@link #reloadables} during this block
 	 */
 	private boolean startingReloadables = false;
+	
+	/**
+	 * For your convenience, the Foundation library will automatically disable the plugin should it be executed in an
+	 * unsupported environment, such as a very new or old Minecraft version. You can disable this safety check here.
+	 * Please not that it must be disabled before {@link #onPluginPreStart()} is called.
+	 */
+	private boolean safeLoad = true;
 
 	// ----------------------------------------------------------------------------------------
 	// Main methods
@@ -212,8 +219,8 @@ public abstract class SimplePlugin extends JavaPlugin implements Listener {
 		if (!isEnabled)
 			return;
 
-		// Before all, check if necessary libraries and the minimum required MC version
-		if (!checkLibraries0() || !checkServerVersions0()) {
+		// Before all, check if necessary libraries and the minimum required MC version (if safeLoad is true)
+		if (!checkLibraries0() || (safeLoad && !checkServerVersions0())) {
 			isEnabled = false;
 			setEnabled(false);
 
@@ -1070,6 +1077,13 @@ public abstract class SimplePlugin extends JavaPlugin implements Listener {
 	@Override
 	protected final File getFile() {
 		return super.getFile();
+	}
+	
+	/**
+	 * Set whether or not the plugin should load safely and disable for unsupported versions. Use at your own risk.
+	 */
+	protected void setSafeLoad(boolean value) {
+		this.safeLoad = value;
 	}
 
 	/**


### PR DESCRIPTION
This change will allow for a developer to force the plugin to load anyways should the Minecraft version be unsupported by Foundation (untested). This will allow more advanced users of the library to update their servers without any unnecessary dependence on the Mineacademy team. The primary use case of this feature would be to allow servers and networks to update their codebases as fast as possible should new snapshots be released.