### PR TITLE
Fix NullPointerException in Button#toString

### DIFF
--- a/src/main/java/org/mineacademy/fo/menu/button/Button.java
+++ b/src/main/java/org/mineacademy/fo/menu/button/Button.java
@@ -207,7 +207,9 @@ public abstract class Button {
 
 	@Override
 	public final String toString() {
-		return getClass().getSimpleName() + "{" + getItem().getType() + "}";
+		final ItemStack item = getItem();
+
+		return getClass().getSimpleName() + "{" + (item != null ? item.getType() : "null") + "}";
 	}
 
 	// ----------------------------------------------------------------


### PR DESCRIPTION
When checking if Button#getItem is not null in Menu#getButton, the error message wants to print the item's type, so it throws NullPointerException