### PR TITLE
Update Towny Repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
 		<dependency>
 			<groupId>org.mineacademy.plugin</groupId>
 			<artifactId>Towny</artifactId>
-			<version>0.96.2.0</version>
+			<version>0.96.7.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mineacademy.plugin</groupId>


### PR DESCRIPTION
There are many major changes since the version of towny that Foundation currently uses that causes a lot of gaps in compatibility. Fortunately, none of the HookManager methods take advantage of any of the updated Towny API so they do not need to be adjusted.