### PR TITLE
Add CustomModelData to ItemCreator and append using an array in SimpleComponent

### DIFF
--- a/src/main/java/org/mineacademy/fo/menu/model/ItemCreator.java
+++ b/src/main/java/org/mineacademy/fo/menu/model/ItemCreator.java
@@ -121,6 +121,11 @@ public final class ItemCreator {
 	private boolean hideTags = false;
 
 	/**
+	 * The custom model data of the item
+	 */
+	private int modelData;
+
+	/**
 	 * Should we add glow to the item? (adds a fake enchant and uses {@link ItemFlag}
 	 * to hide it). The enchant is visible on older MC versions.
 	 */
@@ -339,6 +344,18 @@ public final class ItemCreator {
 	 */
 	public ItemCreator hideTags(boolean hideTags) {
 		this.hideTags = hideTags;
+
+		return this;
+	}
+
+	/**
+	 * Set the Custom Model Data of this item, compatible with +1.14.x
+	 *
+	 * @param modelData
+	 * @return
+	 */
+	public ItemCreator modelData(int modelData) {
+		this.modelData = modelData;
 
 		return this;
 	}
@@ -676,6 +693,14 @@ public final class ItemCreator {
 
 		// Apply custom enchantment lores
 		compiledItem = Common.getOrDefault(SimpleEnchantment.addEnchantmentLores(compiledItem), compiledItem);
+
+		// Set custom model data
+		if (this.modelData > 0 && MinecraftVersion.atLeast(V.v1_14))
+			try {
+				((ItemMeta) compiledMeta).setCustomModelData(this.modelData);
+			} catch (final Throwable t) {
+			}
+
 
 		// 1.7.10 hack to add glow, requires no enchants
 		if (this.glow && MinecraftVersion.equals(V.v1_7) && (this.enchants == null || this.enchants.isEmpty())) {

--- a/src/main/java/org/mineacademy/fo/model/SimpleComponent.java
+++ b/src/main/java/org/mineacademy/fo/model/SimpleComponent.java
@@ -217,6 +217,21 @@ public final class SimpleComponent implements ConfigSerializable {
 	/**
 	 * Append text to this simple component
 	 *
+	 * @param strings
+	 * @return
+	 */
+	public SimpleComponent append(String... strings) {
+		String text = null;
+		for (String string : strings) {
+			text = text + string + "\n";
+		}
+		return this.append(text);
+
+	}
+
+	/**
+	 * Append text to this simple component
+	 *
 	 * @param text
 	 * @return
 	 */
@@ -696,6 +711,21 @@ public final class SimpleComponent implements ConfigSerializable {
 	 */
 	public static SimpleComponent empty() {
 		return of(true, "");
+	}
+
+	/**
+	 * Create a new interactive chat component
+	 * You can then build upon your text to add interactive elements
+	 *
+	 * @param strings
+	 * @return
+	 */
+	public static SimpleComponent of(String... strings) {
+		String text = null;
+		for (String string : strings) {
+			text = text + string + "\n";
+		}
+		return of(text);
 	}
 
 	/**


### PR DESCRIPTION
Add CustomModelData setting to ItemCreator that was added in 1.14. CustomModelData is a numeric NBT Tag used to make multiple textures for the same item using different numeric combinations. 

Add option to use String array in append() and of() methods in SimpleComponent to easier multi-line components. 