### PR TITLE
Add methodCache to fix lag when running /chc log

### DIFF
--- a/src/main/java/org/mineacademy/fo/ReflectionUtil.java
+++ b/src/main/java/org/mineacademy/fo/ReflectionUtil.java
@@ -67,6 +67,7 @@ public final class ReflectionUtil {
 	 */
 	private static final Map<String, Class<?>> classCache = new ConcurrentHashMap<>();
 	private static final Map<Class<?>, ReflectionData<?>> reflectionDataCache = new ConcurrentHashMap<>();
+	private static final Map<Class<?>, Method[]> methodCache = new ConcurrentHashMap<>();
 	private static final Collection<String> classNameGuard = ConcurrentHashMap.newKeySet();
 
 	/**
@@ -315,7 +316,8 @@ public final class ReflectionUtil {
 	 * @return
 	 */
 	public static Method getMethod(final Class<?> clazz, final String methodName, final Class<?>... args) {
-		for (final Method method : clazz.getMethods())
+		Method[] methods = methodCache.computeIfAbsent(clazz, k -> clazz.getMethods());
+		for (final Method method : methods)
 			if (method.getName().equals(methodName) && isClassListEqual(args, method.getParameterTypes())) {
 				method.setAccessible(true);
 

--- a/src/main/java/org/mineacademy/fo/ReflectionUtil.java
+++ b/src/main/java/org/mineacademy/fo/ReflectionUtil.java
@@ -316,6 +316,12 @@ public final class ReflectionUtil {
 	 * @return
 	 */
 	public static Method getMethod(final Class<?> clazz, final String methodName, final Class<?>... args) {
+		try {
+			Method method = clazz.getMethod(methodName, args);
+			method.setAccessible(true);
+			return method;
+		} catch (NoSuchMethodException e) {}
+
 		Method[] methods = methodCache.computeIfAbsent(clazz, k -> clazz.getMethods());
 		for (final Method method : methods)
 			if (method.getName().equals(methodName) && isClassListEqual(args, method.getParameterTypes())) {


### PR DESCRIPTION
Currently, `/chc log` causes lag because the `clazz.getMethods()` call is quite expensive and it's called a lot in the sync part when doing `params.get...`. I added a cache for the `getMethods()` call, which seems to fix the lag and I also try to get the method with getMethod first.