### PR TITLE
Change Integer to UUID in WrappedGameProfile

### DIFF
--- a/src/main/java/org/mineacademy/fo/PacketUtil.java
+++ b/src/main/java/org/mineacademy/fo/PacketUtil.java
@@ -5,6 +5,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.UUID;
 
 import org.bukkit.entity.Player;
 import org.mineacademy.fo.MinecraftVersion.V;
@@ -132,9 +133,9 @@ public final class PacketUtil {
 	public static List<WrappedGameProfile> compileHoverText(final String... hoverTexts) {
 		final List<WrappedGameProfile> profiles = new ArrayList<>();
 
-		int count = 0;
+
 		for (final String hoverText : hoverTexts)
-			profiles.add(new WrappedGameProfile(String.valueOf(count++), Common.colorize(hoverText)));
+			profiles.add(new WrappedGameProfile(UUID.randomUUID(), Common.colorize(hoverText)));
 
 		return profiles;
 	}


### PR DESCRIPTION
Using Integers for profile UUIDs  in WrappedGameProfile causes warning messages in console from ProtocolLib. When tested using randomUUID() no warning appeared.

Warning message (Shown every time there is a request for packet):

```
[09:05:08 WARN]: [ProtocolLib] [WrappedGameProfile] Plugin nms created a profile with '1' as an UUID.
[09:05:08 WARN]: [ProtocolLib] [WrappedGameProfile] Plugin nms created a profile with '2' as an UUID.
[09:05:08 WARN]: [ProtocolLib] [WrappedGameProfile] Plugin nms created a profile with '3' as an UUID.
[09:05:08 WARN]: [ProtocolLib] [WrappedGameProfile] Plugin nms created a profile with '4' as an UUID.
[09:05:08 WARN]: [ProtocolLib] [WrappedGameProfile] Plugin nms created a profile with '5' as an UUID.
[09:05:08 WARN]: [ProtocolLib] [WrappedGameProfile] Plugin nms created a profile with '6' as an UUID.
[09:05:08 WARN]: [ProtocolLib] [WrappedGameProfile] Plugin nms created a profile with '7' as an UUID.
[09:05:08 WARN]: [ProtocolLib] [WrappedGameProfile] Plugin nms created a profile with '8' as an UUID.
[09:05:08 WARN]: [ProtocolLib] [WrappedGameProfile] Plugin nms created a profile with '9' as an UUID.
[09:05:08 WARN]: [ProtocolLib] [WrappedGameProfile] Plugin nms created a profile with '10' as an UUID.
[09:05:08 WARN]: [ProtocolLib] [WrappedGameProfile] Plugin nms created a profile with '11' as an UUID.
[09:05:08 WARN]: [ProtocolLib] [WrappedGameProfile] Plugin nms created a profile with '12' as an UUID.
```