### PR TITLE
Fixed swap to offhand give you menu item.

### DIFF
--- a/src/main/java/org/mineacademy/fo/menu/MenuListener.java
+++ b/src/main/java/org/mineacademy/fo/menu/MenuListener.java
@@ -1,26 +1,31 @@
 package org.mineacademy.fo.menu;
 
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event.Result;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.inventory.InventoryAction;
-import org.bukkit.event.inventory.InventoryClickEvent;
-import org.bukkit.event.inventory.InventoryCloseEvent;
-import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.event.inventory.*;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.mineacademy.fo.Common;
+import org.mineacademy.fo.MinecraftVersion;
 import org.mineacademy.fo.menu.button.Button;
 import org.mineacademy.fo.menu.model.MenuClickLocation;
 import org.mineacademy.fo.remain.Remain;
 import org.mineacademy.fo.settings.SimpleLocalization;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
 /**
  * The bukkit listener responsible for menus to function.
  */
 public final class MenuListener implements Listener {
+
+	private final Map<UUID, SwapData> cacheData = new HashMap<>();
 
 	/**
 	 * Handles closing menus
@@ -34,9 +39,26 @@ public final class MenuListener implements Listener {
 
 		final Player player = (Player) event.getPlayer();
 		final Menu menu = Menu.getMenu(player);
-
-		if (menu != null)
+		if (menu != null) {
 			menu.handleClose(event.getInventory());
+			addItemsToPlayer(player);
+		}
+	}
+
+	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+	public void onMenuOpen(final InventoryOpenEvent event) {
+		if (!(event.getPlayer() instanceof Player))
+			return;
+		if (event.getInventory().getType() == InventoryType.PLAYER)
+			return;
+
+		final Player player = (Player) event.getPlayer();
+		if (MinecraftVersion.atLeast(MinecraftVersion.V.v1_14))
+			Common.runLater(3, () -> {
+				final Menu menu = Menu.getMenu(player);
+				if (menu != null)
+					cacheData.put(player.getUniqueId(), new SwapData(false, player.getInventory().getItemInOffHand()));
+			});
 	}
 
 	/**
@@ -87,9 +109,50 @@ public final class MenuListener implements Listener {
 
 			} else if (action == InventoryAction.MOVE_TO_OTHER_INVENTORY || whereClicked != MenuClickLocation.PLAYER_INVENTORY) {
 				event.setResult(Result.DENY);
-
+				checkIfPlayerSwapItem(event, player);
 				player.updateInventory();
 			}
+		}
+	}
+
+	private void checkIfPlayerSwapItem(InventoryClickEvent event, Player player) {
+
+		if (event.getClick().toString().contains("SWAP_OFFHAND")) {
+			SwapData data = cacheData.get(player.getUniqueId());
+			ItemStack item = null;
+			if (data != null) {
+				item = data.getItemInOfBeforeOpenMenuHand();
+			}
+			cacheData.put(player.getUniqueId(), new SwapData(true, item));
+		}
+	}
+
+	private void addItemsToPlayer(Player player) {
+
+		SwapData data = cacheData.get(player.getUniqueId());
+		if (data != null && data.isPlayerUseSwapoffhand())
+			if (data.getItemInOfBeforeOpenMenuHand() != null && data.getItemInOfBeforeOpenMenuHand().getType() != Material.AIR)
+				player.getInventory().setItemInOffHand(data.getItemInOfBeforeOpenMenuHand());
+			else
+				player.getInventory().setItemInOffHand(null);
+		cacheData.remove(player.getUniqueId());
+	}
+
+	private static class SwapData {
+		boolean playerUseSwapoffhand;
+		ItemStack itemInOfBeforeOpenMenuHand;
+
+		public SwapData(boolean playerUseSwapoffhand, ItemStack itemInOfBeforeOpenMenuHand) {
+			this.playerUseSwapoffhand = playerUseSwapoffhand;
+			this.itemInOfBeforeOpenMenuHand = itemInOfBeforeOpenMenuHand;
+		}
+
+		public boolean isPlayerUseSwapoffhand() {
+			return playerUseSwapoffhand;
+		}
+
+		public ItemStack getItemInOfBeforeOpenMenuHand() {
+			return itemInOfBeforeOpenMenuHand;
 		}
 	}
 }


### PR DESCRIPTION
Is little hacky solution but it is working. I try it in 1.8.8,1.121.13 and 1.16.5 (so it not give errors this code works only from 1.16 and up). Shall also work in 1.18.1 (with out the code i added you get same issue).

 I get some ideas here https://www.spigotmc.org/threads/prevent-people-from-swapping-to-the-offhand-when-in-an-inventory.465927/ but is my own solution. 

I come across this issue when clicking on switch button of mistake (I also remember you say something about this before). 

So it always remember the item you have in offhand no mater if you open several menus (don´t know if the delay I have to add mess up something (not try that out)).