### PR TITLE
Typo fix

### DIFF
--- a/src/main/java/org/mineacademy/fo/database/SimpleDatabase.java
+++ b/src/main/java/org/mineacademy/fo/database/SimpleDatabase.java
@@ -165,7 +165,7 @@ public class SimpleDatabase {
 					ReflectionUtil.invoke("setDriverClassName", hikariConfig, "org.mariadb.jdbc.Driver");
 
 				else
-					throw new FoException("Illegal database driver, expected jdbc:mysqlf or jdbc:mariadb for Hikari, got: " + url);
+					throw new FoException("Unknown database driver, expected jdbc:mysql or jdbc:mariadb, got: " + url);
 
 				ReflectionUtil.invoke("setJdbcUrl", hikariConfig, url);
 				ReflectionUtil.invoke("setUsername", hikariConfig, user);


### PR DESCRIPTION
- Changed "Illegal" to "Unknown" as this fits the situation a bit better.
- Fixed a typo : `mysqlf`
- Removed "for Hiakri" as it's not necessary, no matter if HikariCP is enabled or not, users are still able to use MariaDB/MySQL JDBC Drivers