### PR TITLE
Lower version check to Java 9

### DIFF
--- a/src/main/java/org/mineacademy/fo/plugin/SimplePlugin.java
+++ b/src/main/java/org/mineacademy/fo/plugin/SimplePlugin.java
@@ -394,7 +394,7 @@ public abstract class SimplePlugin extends JavaPlugin implements Listener {
 		}
 
 		// Load normally
-		if (!libraries.isEmpty() && Remain.getJavaVersion() >= 15)
+		if (!libraries.isEmpty() && Remain.getJavaVersion() >= 9)
 			Common.logFramed(
 					"Warning: Unsupported Java version: " + Remain.getJavaVersion() + " for your server",
 					"version! Minecraft " + MinecraftVersion.getServerVersion() + " was designed for Java 8",


### PR DESCRIPTION
The URLClassLoader.addURL method seems to cause issues with java versions above java 8.
This makes the check more accurate as users with java 11 or 14 (which are widely used by server below 1.16) will encounter issues.