### PR TITLE
Fix color code detection at the end of urls

### DIFF
--- a/src/main/java/org/mineacademy/fo/model/SimpleComponent.java
+++ b/src/main/java/org/mineacademy/fo/model/SimpleComponent.java
@@ -39,7 +39,7 @@ public final class SimpleComponent implements ConfigSerializable {
 	/**
 	 * The pattern to match URL addresses when parsing text
 	 */
-	private static final Pattern URL_PATTERN = Pattern.compile("^(?:(https?)://)?([-\\w_\\.]{2,}\\.[a-z]{2,4})(/\\S*)?$");
+	private static final Pattern URL_PATTERN = Pattern.compile("^(?:(https?)://)?([-\\w_\\.]{2,}\\.[a-z]{2,4})(/\\S*)?[^&rR]$");
 
 	/**
 	 * The past components

--- a/src/main/java/org/mineacademy/fo/model/SimpleComponent.java
+++ b/src/main/java/org/mineacademy/fo/model/SimpleComponent.java
@@ -39,7 +39,7 @@ public final class SimpleComponent implements ConfigSerializable {
 	/**
 	 * The pattern to match URL addresses when parsing text
 	 */
-	private static final Pattern URL_PATTERN = Pattern.compile("^(?:(https?)://)?([-\\w_\\.]{2,}\\.[a-z]{2,4})(/\\S*)?[^&rR]$");
+	private static final Pattern URL_PATTERN = Pattern.compile("^(?:(https?)://)?([-\\w_\\.]{2,}\\.[a-z]{2,4})(/\\S*)?([^&]+[^0-9a-fk-orA-FK-OR])$");
 
 	/**
 	 * The past components


### PR DESCRIPTION
This will solve an issue reported by someone on discord resulting in underline color code not properly resetting when used in urls like `google.com/map`.