### PR TITLE
Fix longer domains like `.network` not being detected

### DIFF
--- a/src/main/java/org/mineacademy/fo/model/SimpleComponent.java
+++ b/src/main/java/org/mineacademy/fo/model/SimpleComponent.java
@@ -40,7 +40,7 @@ public final class SimpleComponent implements ConfigSerializable {
 	/**
 	 * The pattern to match URL addresses when parsing text
 	 */
-	private static final Pattern URL_PATTERN = Pattern.compile("^(https?:\\/\\/|)(www\\.|)[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b(?:[a-zA-Z:,.\\?\\!\\/0-9]*)$");
+	private static final Pattern URL_PATTERN = Pattern.compile("^(https?:\\/\\/|)(www\\.|)[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,12}\\b(?:[a-zA-Z:,.\\?\\!\\/0-9]*)$");
 
 	/**
 	 * The past components

--- a/src/main/java/org/mineacademy/fo/model/SimpleComponent.java
+++ b/src/main/java/org/mineacademy/fo/model/SimpleComponent.java
@@ -40,7 +40,7 @@ public final class SimpleComponent implements ConfigSerializable {
 	/**
 	 * The pattern to match URL addresses when parsing text
 	 */
-	private static final Pattern URL_PATTERN = Pattern.compile("^(https?:\\/\\/|)(www\\.|)[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,12}\\b(?:[a-zA-Z:,.\\?\\!\\/0-9]*)$");
+	private static final Pattern URL_PATTERN = Pattern.compile("^(https?:\\/\\/|)(www\\.|)[\\w-:._\\d]{1,256}\\.[\\w()]{1,12}\\b([\\w-@:%.,_+~#=?!&$/\\d]*)$");
 
 	/**
 	 * The past components

--- a/src/main/java/org/mineacademy/fo/model/SimpleComponent.java
+++ b/src/main/java/org/mineacademy/fo/model/SimpleComponent.java
@@ -40,7 +40,7 @@ public final class SimpleComponent implements ConfigSerializable {
 	/**
 	 * The pattern to match URL addresses when parsing text
 	 */
-	private static final Pattern URL_PATTERN = Pattern.compile("^(https?:\\/\\/|)(www\\.|)[\\w-:._\\d]{1,256}\\.[\\w()]{1,12}\\b([\\w-@:%.,_+~#=?!&$/\\d]*)$");
+	private static final Pattern URL_PATTERN = Pattern.compile("^(https?:\\/\\/|)(www\\.|)[\\w-:.\\d]{1,256}\\.[\\w()]{1,12}\\b([\\w-@:%.,+~#=?!&$/\\d]*)$");
 
 	/**
 	 * The past components


### PR DESCRIPTION
This fixes https://github.com/kangarko/ChatControl-Red/issues/2065

I also reduced the size of the regex and removed useless characters check. Tested with a lot of examples, and they all work fine.

However I did notice one issue (that was already happening before the changes made to the regex):
- links ending with a color code cannot be clicked in chat. I don't really know if this can easily be fixed since links can contain parts like `&part1?&part2?` etc...
Honestly this is a pretty small bug considering this can be easily fixed by the users by simply replacing a message like `&egoogle.com&r join our discord server` with `&egoogle.com &rjoin our discord server`

```
match ^/(hi)
then replace optifine.net optifine.com optifine.network
```

So this is ready to merge according to my tests (I made the same tests than #2041 and also checked a lot of different links like these ones
![image](https://user-images.githubusercontent.com/53318613/184557374-1c3fbc60-70a2-413a-be02-abaefeaa5328.png)