### PR TITLE
Small change to the debug feature

### DIFF
--- a/src/main/java/org/mineacademy/fo/command/DebugCommand.java
+++ b/src/main/java/org/mineacademy/fo/command/DebugCommand.java
@@ -81,7 +81,7 @@ public final class DebugCommand extends SimpleSubCommand {
 				" Debug log generated " + TimeUtil.getFormattedDate(),
 				Common.consoleLine(),
 				"Plugin: " + SimplePlugin.getInstance().getDescription().getFullName(),
-				"Server Version: " + Bukkit.getName() + " " + MinecraftVersion.getServerVersion(),
+				"Server Version: " + Bukkit.getVersion(),
 				"Java: " + System.getProperty("java.version") + " (" + System.getProperty("java.specification.vendor") + "/" + System.getProperty("java.vm.vendor") + ")",
 				"OS: " + System.getProperty("os.name") + " " + System.getProperty("os.version"),
 				"Online mode: " + Bukkit.getOnlineMode(),


### PR DESCRIPTION
- The debug feature now gets the full server version (including the build number)


We also noticed with Intolerant and another user on discord that the `BungeeCord` part of the `general.txt` file always returns `null` with the latest versions. Same thing happens with the `MySQL:` part, except it always returns `false` (I did try to reproduce the issue on my side, and I was actually able to).