### PR TITLE
Minor logging changes

### DIFF
--- a/src/main/java/org/mineacademy/fo/plugin/SimplePlugin.java
+++ b/src/main/java/org/mineacademy/fo/plugin/SimplePlugin.java
@@ -229,12 +229,12 @@ public abstract class SimplePlugin extends JavaPlugin implements Listener {
 				&& !version.contains("-Spigot")
 				&& MinecraftVersion.atLeast(V.v1_8)) {
 			this.getLogger().warning(Common.consoleLine());
-			this.getLogger().warning("Warning about " + named + ": You're not using Paper!");
+			this.getLogger().warning("You're not using Paper!");
 			this.getLogger().warning("Detected: " + version);
 			this.getLogger().warning("");
-			this.getLogger().warning("Third party forks are known to alter server in unwanted");
-			this.getLogger().warning("ways. If you have issues with " + named + " use Paper");
-			this.getLogger().warning("from PaperMC.io otherwise you may not receive our support.");
+			this.getLogger().warning("Third party forks are known to alter server in unwanted ways.");
+			this.getLogger().warning("If you experience issues with " + named + ", download Paper");
+			this.getLogger().warning("from PaperMC.io, otherwise you may not receive support.");
 			this.getLogger().warning(Common.consoleLine());
 		}
 

--- a/src/main/java/org/mineacademy/fo/plugin/SimplePlugin.java
+++ b/src/main/java/org/mineacademy/fo/plugin/SimplePlugin.java
@@ -227,14 +227,14 @@ public abstract class SimplePlugin extends JavaPlugin implements Listener {
 				&& !version.contains("NachoSpigot")
 				&& !version.contains("-Spigot")
 				&& MinecraftVersion.atLeast(V.v1_8)) {
-			Bukkit.getLogger().severe(Common.consoleLine());
-			Bukkit.getLogger().warning("Warning about " + named + ": You're not using Paper!");
-			Bukkit.getLogger().warning("Detected: " + version);
-			Bukkit.getLogger().warning("");
-			Bukkit.getLogger().warning("Third party forks are known to alter server in unwanted");
-			Bukkit.getLogger().warning("ways. If you have issues with " + named + " use Paper");
-			Bukkit.getLogger().warning("from PaperMC.io otherwise you may not receive our support.");
-			Bukkit.getLogger().severe(Common.consoleLine());
+			this.getLogger().warning(Common.consoleLine());
+			this.getLogger().warning("Warning about " + named + ": You're not using Paper!");
+			this.getLogger().warning("Detected: " + version);
+			this.getLogger().warning("");
+			this.getLogger().warning("Third party forks are known to alter server in unwanted");
+			this.getLogger().warning("ways. If you have issues with " + named + " use Paper");
+			this.getLogger().warning("from PaperMC.io otherwise you may not receive our support.");
+			this.getLogger().warning(Common.consoleLine());
 		}
 
 		// Load libraries where Spigot does not do this automatically
@@ -249,7 +249,7 @@ public abstract class SimplePlugin extends JavaPlugin implements Listener {
 
 		// Disabled upstream
 		if (!this.canLoad) {
-			Bukkit.getLogger().severe("Not loading, the plugin is disabled (look for console errors above)");
+			this.getLogger().severe("Not loading, the plugin is disabled (look for console errors above)");
 
 			return;
 		}


### PR DESCRIPTION
Someone on discord requested us to get rid of the severe warning level when it's not useful (which is right imo).
I also replaced Bukkit's internal logger with Java one, as this is something actually highly suggested. (It also allows log messages to start with the plugin name, this way there's no need to manually add it, and it makes logs a bit more readable).