### PR TITLE
Small fix

### DIFF
--- a/src/main/java/org/mineacademy/fo/remain/CompChatColor.java
+++ b/src/main/java/org/mineacademy/fo/remain/CompChatColor.java
@@ -259,7 +259,7 @@ public final class CompChatColor {
 	 * @return
 	 */
 	public String toEscapedString() {
-		return this.isHex() ? this.toString + "\\\\" + this.getName() : ItemUtil.bountify(this.getName());
+		return this.isHex() ? this.toString + "\\\\" + this.getName() + CompChatColor.RESET : ItemUtil.bountify(this.getName());
 	}
 
 	/**


### PR DESCRIPTION
Fix for colors being set for the entire message when using CompChatColor.toEscapedString()