### PR TITLE
Fix PlayerUtil.normalize method setting the fly speed too high

### DIFF
--- a/src/main/java/org/mineacademy/fo/PlayerUtil.java
+++ b/src/main/java/org/mineacademy/fo/PlayerUtil.java
@@ -469,7 +469,7 @@ public final class PlayerUtil {
 			player.setAllowFlight(false);
 			player.setFlying(false);
 
-			player.setFlySpeed(0.2F);
+			player.setFlySpeed(0.1F);
 			player.setWalkSpeed(0.2F);
 
 			player.setCanPickupItems(true);


### PR DESCRIPTION
The default flight speed should be 0.1, not 0.2. The PlayerUtil.normalize method wrongly sets it to 0.2.