### PR TITLE
Update ChatUtil.java

### DIFF
--- a/src/main/java/org/mineacademy/fo/ChatUtil.java
+++ b/src/main/java/org/mineacademy/fo/ChatUtil.java
@@ -122,7 +122,7 @@ public final class ChatUtil {
 		double compensated = 0;
 
 		while (compensated < toCompensate) {
-			builder.append(" ");
+			builder.append(space);
 
 			compensated += spaceLength;
 		}


### PR DESCRIPTION
Fixed an issue where the provided final char space was not being included in the string builder in the center function.

Prior to fix:
`
center("My Plugin",  '=', 152);

"                                        My Plugin                                         "
`

Post fix:
`
center("My Plugin",  '=', 152);

"=============== My Plugin ==============="
`