### PR TITLE
Added protected access modifier to Menu#onRestart()

### DIFF
--- a/src/main/java/org/mineacademy/fo/menu/Menu.java
+++ b/src/main/java/org/mineacademy/fo/menu/Menu.java
@@ -534,7 +534,6 @@ public abstract class Menu {
 
 		this.registerButtons();
 
-		// Call before calling getItemAt
 		this.onRestart();
 
 		ItemStack[] content = inventory.getContents();
@@ -549,10 +548,10 @@ public abstract class Menu {
 			this.animateTitle(animatedTitle);
 	}
 
-	/*
-	 * Internal hook before calling getItemAt
+	/** 
+	 * Called automatically when a menu is restarted. Called before getItemAt() and after registerButtons()
 	 */
-	void onRestart() {
+	protected void onRestart() {
 	}
 
 	/**


### PR DESCRIPTION
Menu#onRestart() did not have an access modifier. 

[+] Added the "protected" access modifier to allow extended classes to be able to hook into menu restarts