### PR TITLE
Fix tellJson logic for handling Conversable instances

### DIFF
--- a/src/main/java/org/mineacademy/fo/Common.java
+++ b/src/main/java/org/mineacademy/fo/Common.java
@@ -494,16 +494,19 @@ public final class Common {
 				if (sender instanceof Conversable) {
 					final Conversable conversable = (Conversable) sender;
 
-					if (conversable.isConversing())
+					if (conversable.isConversing()) {
 						conversable.sendRawMessage(toSend);
-				} else
-					try {
-						sender.sendMessage(toSend);
-					} catch (final Throwable t) {
-						Bukkit.getLogger().severe("Failed to send message to " + sender.getName() + ", message: '" + toSend + "'.");
-
-						t.printStackTrace();
+						return;
 					}
+				}
+				
+				try {
+					sender.sendMessage(toSend);
+				} catch (final Throwable t) {
+					Bukkit.getLogger().severe("Failed to send message to " + sender.getName() + ", message: '" + toSend + "'.");
+
+					t.printStackTrace();
+				}
 			}
 	}
 


### PR DESCRIPTION
Removed the redundant `else` block. 
This ensures that if the sender is not a conversing `Conversable`, the message will be sent normally.