### PR TITLE
Reset player's attack speed in #normalize

### DIFF
--- a/src/main/java/org/mineacademy/fo/PlayerUtil.java
+++ b/src/main/java/org/mineacademy/fo/PlayerUtil.java
@@ -416,6 +416,7 @@ public final class PlayerUtil {
 
 				try {
 					CompAttribute.GENERIC_MAX_HEALTH.set(player, 20);
+					CompAttribute.GENERIC_ATTACK_SPEED.set(player, 4.0);
 
 				} catch (final Throwable t) {
 					try {


### PR DESCRIPTION
According to the docs: https://minecraft.fandom.com/wiki/Attribute default player's attack speed is 4.0.

I had an issue, that after joining a minigame and calling #normalize, attack speed was not reset. 