### PR TITLE
Added primary thread check to CompProperty#applyLegacy

### DIFF
--- a/src/main/java/org/mineacademy/fo/remain/CompProperty.java
+++ b/src/main/java/org/mineacademy/fo/remain/CompProperty.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -111,6 +112,7 @@ public enum CompProperty {
 	}
 
 	private void applyLegacy(Object instance, Object key) {
+		Valid.checkBoolean(Bukkit.isPrimaryThread(), "Cannot invoke CompProperty#applyLegacy off primary thread");
 		if (instance instanceof Entity) {
 			final NBTEntity nbtEntity = new NBTEntity((Entity) instance);
 			final boolean has = Boolean.parseBoolean(key.toString());


### PR DESCRIPTION
I was using PlayerUtil#normalize, which stopped all code execution after invoking it. this was due to an NbtApiException being thrown silently. the NbtApiException was thrown because NBT-API was being accessed off the main thread in CompPropery#applyLegacy, i added a check in there so future users are not head scratching for an hour. perhaps it should be handled differently though.

at least now it will let you know what the problem is.