### PR TITLE
Fixed NoSuchFieldException

### DIFF
--- a/src/main/java/org/mineacademy/fo/remain/Remain.java
+++ b/src/main/java/org/mineacademy/fo/remain/Remain.java
@@ -2628,8 +2628,16 @@ public final class Remain {
 			final boolean mojMap = Remain.isUsingMojangMappings();
 			final Object enchantmentRegistry = getEnchantRegistry();
 
-			ReflectionUtil.setDeclaredField(enchantmentRegistry, mojMap ? "frozen" : "l", false); // MappedRegistry#frozen
-			ReflectionUtil.setDeclaredField(enchantmentRegistry, mojMap ? "unregisteredIntrusiveHolders" : "m", new IdentityHashMap<>()); // MappedRegistry#unregisteredIntrusiveHolders
+			try {
+				// works fine in versions (1.19.3 and up)
+				ReflectionUtil.setDeclaredField(enchantmentRegistry, mojMap ? "frozen" : "l", false); // MappedRegistry#frozen
+				ReflectionUtil.setDeclaredField(enchantmentRegistry, mojMap ? "unregisteredIntrusiveHolders" : "m", new IdentityHashMap<>()); // MappedRegistry#unregisteredIntrusiveHolders
+			}catch (Throwable throwable) {
+				// in (1.19 - 1.19.2) the obfuscation is different.
+				ReflectionUtil.setDeclaredField(enchantmentRegistry, mojMap ? "frozen" : "ca", false); // MappedRegistry#frozen
+				// unregisteredIntrusiveHolders does not exist in this version
+			}
+
 		}
 
 		if (MinecraftVersion.olderThan(V.v1_20))


### PR DESCRIPTION
Unfortunately this new method  will cause a NoSuchFieldException when the server is running on 1.19-1.19.2, due to obfuscation changes.

i implemented a quick fix. but the field unregisteredIntrusiveHolders does not exist in these versions at all. so it might need to be implemented differently  there. (i don't know what this method is used for so its a bit difficult for me to do.)