### PR TITLE
Fix error with a toast message on newer minecraft versions.

### DIFF
--- a/src/main/java/org/mineacademy/fo/remain/Remain.java
+++ b/src/main/java/org/mineacademy/fo/remain/Remain.java
@@ -3412,7 +3412,10 @@ class AdvancementAccessor {
 		final JsonObject json = new JsonObject();
 
 		final JsonObject icon = new JsonObject();
-		icon.addProperty("item", this.icon);
+		if (MinecraftVersion.atLeast(V.v1_20)) {
+			icon.addProperty("id", this.icon);
+		} else
+			icon.addProperty("item", this.icon);
 
 		final JsonObject display = new JsonObject();
 		display.add("icon", icon);


### PR DESCRIPTION
Starting at version `1.20.5` was change in json that send toast message. Instead `item` is `id`.
But by only supporting the latest Subversion in a given version, we only check 1.20 without subversions.