### PR TITLE
Implement shift click ability 

### DIFF
--- a/src/main/java/org/mineacademy/fo/menu/Menu.java
+++ b/src/main/java/org/mineacademy/fo/menu/Menu.java
@@ -655,6 +655,19 @@ public abstract class Menu {
 	}
 
 	/**
+	 * If you want to allow shift click on a menu item.
+	 * Default will this return false. Compare to the
+	 * {@link #isAllowShift()} method you can with this
+	 * method only allow the click in specific slots.
+	 *
+	 * @param slot the slot player clicking on.
+	 * @return true if allow the click.
+	 */
+	public boolean isAllowShift(int slot) {
+			return false;
+	}
+
+	/**
 	 * Draws the bottom bar for the player inventory
 	 *
 	 * @return

--- a/src/main/java/org/mineacademy/fo/menu/Menu.java
+++ b/src/main/java/org/mineacademy/fo/menu/Menu.java
@@ -161,6 +161,13 @@ public abstract class Menu {
 	private boolean opened = false;
 
 	/**
+	 * If you want to allow shift click on a menu item.
+	 * Default will this return false.
+	*/
+	@Getter
+	@Setter
+	private boolean allowShift = false;
+	/**
 	 * Special case button only registered if this menu is {@link MenuQuantitable}
 	 */
 	@Nullable

--- a/src/main/java/org/mineacademy/fo/menu/MenuListener.java
+++ b/src/main/java/org/mineacademy/fo/menu/MenuListener.java
@@ -87,7 +87,7 @@ public final class MenuListener implements Listener {
 			final MenuClickLocation whereClicked = clickedInv != null ? clickedInv.getType() == InventoryType.CHEST ? MenuClickLocation.MENU : MenuClickLocation.PLAYER_INVENTORY : MenuClickLocation.OUTSIDE;
 
 			final boolean allowed = menu.isActionAllowed(whereClicked, slot, slotItem, cursor, action);
-			final boolean clickAllowed = (menu.isAllowShift() && (event.getClick().isRightClick() || event.getClick().isLeftClick())) || action.toString().contains("PICKUP") || action.toString().contains("PLACE") || action.toString().equals("SWAP_WITH_CURSOR");
+			final boolean clickAllowed = ((menu.isAllowShift() || menu.isAllowShift(slot))&& (event.getClick().isRightClick() || event.getClick().isLeftClick())) || action.toString().contains("PICKUP") || action.toString().contains("PLACE") || action.toString().equals("SWAP_WITH_CURSOR");
 
 				if (clickAllowed || action == InventoryAction.CLONE_STACK) {
 				if (whereClicked == MenuClickLocation.MENU && slotItem != null)

--- a/src/main/java/org/mineacademy/fo/menu/MenuListener.java
+++ b/src/main/java/org/mineacademy/fo/menu/MenuListener.java
@@ -87,8 +87,9 @@ public final class MenuListener implements Listener {
 			final MenuClickLocation whereClicked = clickedInv != null ? clickedInv.getType() == InventoryType.CHEST ? MenuClickLocation.MENU : MenuClickLocation.PLAYER_INVENTORY : MenuClickLocation.OUTSIDE;
 
 			final boolean allowed = menu.isActionAllowed(whereClicked, slot, slotItem, cursor, action);
+			final boolean clickAllowed = (menu.isAllowShift() && (event.getClick().isRightClick() || event.getClick().isLeftClick())) || action.toString().contains("PICKUP") || action.toString().contains("PLACE") || action.toString().equals("SWAP_WITH_CURSOR");
 
-			if (action.toString().contains("PICKUP") || action.toString().contains("PLACE") || action.toString().equals("SWAP_WITH_CURSOR") || action == InventoryAction.CLONE_STACK) {
+				if (clickAllowed || action == InventoryAction.CLONE_STACK) {
 				if (whereClicked == MenuClickLocation.MENU && slotItem != null)
 					try {
 						Button button = menu.getButton(slot);

--- a/src/main/java/org/mineacademy/fo/menu/MenuListener.java
+++ b/src/main/java/org/mineacademy/fo/menu/MenuListener.java
@@ -89,7 +89,7 @@ public final class MenuListener implements Listener {
 			final boolean allowed = menu.isActionAllowed(whereClicked, slot, slotItem, cursor, action);
 			final boolean clickAllowed = ((menu.isAllowShift() || menu.isAllowShift(slot))&& (event.getClick().isRightClick() || event.getClick().isLeftClick())) || action.toString().contains("PICKUP") || action.toString().contains("PLACE") || action.toString().equals("SWAP_WITH_CURSOR");
 
-				if (clickAllowed || action == InventoryAction.CLONE_STACK) {
+			if (clickAllowed || action == InventoryAction.CLONE_STACK) {
 				if (whereClicked == MenuClickLocation.MENU && slotItem != null)
 					try {
 						Button button = menu.getButton(slot);


### PR DESCRIPTION
This doesn't change the standard behavior, it will ignore shift click if you not specific turn it on. Added two options one is global but could at least in theory do so player get the menu item (what I know does this happen only on inventory close). It is why it is also a option to just allow in specific slots. But perhaps confusing have two option and only keep one of the methods? 

The isActionAllowed only give the option to allow the player get the item from for example a menu and attempt to use it for something else is not good way to solve the problem, when you just could have a toggle to avoid make it more complicated than it needs to be. 

So what does this add to the table, is you can now add 4 click actions instead of limit to only 2 and if you think is to many click options I can say other popular plugins allow not just 4 options but even a fifth with the q (drop item).  

I have seen others request this over the years and not see the menu option in Foundation as something that could compete with other alternative menu API's (I know at least two) or allow end-users of your API make Plugins where you not have to find ways around this issue with more buttons (as a Minecraft inventory have only limit amount of slots) or create own click logic. 

This code is tested in 1.8.8 and 1.20.4, so I will claim this will not break the old behavior, just add some new alternatives.  

What could be changed is break out the check to own method to make it easier to read. 