### PR TITLE
Improvement: SimpleEnchantment Displaying

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.mineacademy</groupId>
     <artifactId>Foundation</artifactId>
-    <version>6.9.2</version>
+    <version>6.9.3</version>
     <packaging>jar</packaging>
 
     <name>Foundation</name>

--- a/src/main/java/org/mineacademy/fo/enchant/SimpleEnchantment.java
+++ b/src/main/java/org/mineacademy/fo/enchant/SimpleEnchantment.java
@@ -78,6 +78,11 @@ public abstract class SimpleEnchantment implements Listener {
 	private static final Pattern VALID_NAMESPACE = Pattern.compile("[a-z0-9._-]+");
 
 	/**
+	 * default prefix for fake enchants' lore
+	 */
+	private static final String FO_ENCHANT_PREFIX = "&r&7";
+
+	/**
 	 * Registration of custom enchants by their namespaced key.
 	 */
 	private static final StrictSet<SimpleEnchantment> registeredEnchantments = new StrictSet<>();
@@ -567,6 +572,70 @@ public abstract class SimpleEnchantment implements Listener {
 	/**
 	 * Since Minecraft client cannot display custom enchantments we have to add lore manually.
 	 * <p>
+	 * This removes the fake enchant lore for the given item in case client tries to clone the item.
+	 *
+	 * @param item
+	 * @return the modified item or null if item was not edited (no enchants found)
+	 * @deprecated internal use only
+	 */
+	@Deprecated
+	public static ItemStack removeEnchantmentLores(ItemStack item) {
+		if (!item.hasItemMeta())
+			return null;
+
+		final ItemMeta meta = item.getItemMeta();
+
+		if (meta != null && meta.hasLore()) {
+			Map<Enchantment, Integer> enchants = item.getEnchantments();
+			if (enchants.isEmpty())
+				return null;
+
+			final List<String> lore = meta.getLore();
+			final List<String> newLore = new ArrayList<>(lore.size());
+			boolean foEnchanted = false;
+
+			final List<String> colorLess = new ArrayList<>();
+			try {
+				for (final Map.Entry<Enchantment, Integer> entry : enchants.entrySet()) {
+					final Enchantment enchantment = entry.getKey();
+					final SimpleEnchantment simpleEnchantment = fromBukkit(enchantment);
+
+					if (simpleEnchantment != null) {
+						final String loreLine = simpleEnchantment.getLore(entry.getValue());
+
+						if (loreLine != null && !loreLine.isEmpty())
+							colorLess.add(ChatColor.stripColor(Common.colorize(loreLine)));
+					}
+				}
+
+			} catch (final NullPointerException ex) {
+				// Some weird problem in third party plugin
+			}
+
+			for (final String line : lore) {
+				if (colorLess.contains(ChatColor.stripColor(Common.colorize(line)))) {
+					foEnchanted = true;
+				} else {
+					newLore.add(line);
+				}
+			}
+
+			if (!foEnchanted)
+				return null;
+
+			meta.setLore(newLore);
+			item.setItemMeta(meta);
+
+			return item;
+		}
+
+		return null;
+	}
+
+
+	/**
+	 * Since Minecraft client cannot display custom enchantments we have to add lore manually.
+	 * <p>
 	 * This adds the fake enchant lore for the given item in case it does not exist.
 	 *
 	 * @param item
@@ -587,7 +656,7 @@ public abstract class SimpleEnchantment implements Listener {
 					final String lore = simpleEnchantment.getLore(entry.getValue());
 
 					if (lore != null && !lore.isEmpty())
-						customEnchants.add(Common.colorize("&r&7" + lore));
+						customEnchants.add(Common.colorize(FO_ENCHANT_PREFIX + lore));
 				}
 			}
 

--- a/src/main/java/org/mineacademy/fo/enchant/SimpleEnchantment.java
+++ b/src/main/java/org/mineacademy/fo/enchant/SimpleEnchantment.java
@@ -28,6 +28,7 @@ import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.entity.ProjectileLaunchEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.projectiles.ProjectileSource;
 import org.mineacademy.fo.ChatUtil;
@@ -587,7 +588,8 @@ public abstract class SimpleEnchantment implements Listener {
 
 		if (meta != null && meta.hasLore()) {
 			Map<Enchantment, Integer> enchants = item.getEnchantments();
-			if (enchants.isEmpty())
+			Map<Enchantment, Integer> storedEnchants = meta instanceof EnchantmentStorageMeta ? ((EnchantmentStorageMeta) meta).getStoredEnchants() : null;
+			if (enchants.isEmpty() && storedEnchants == null && !storedEnchants.isEmpty())
 				return null;
 
 			final List<String> lore = meta.getLore();
@@ -599,6 +601,18 @@ public abstract class SimpleEnchantment implements Listener {
 				for (final Map.Entry<Enchantment, Integer> entry : enchants.entrySet()) {
 					final Enchantment enchantment = entry.getKey();
 					final SimpleEnchantment simpleEnchantment = fromBukkit(enchantment);
+
+					if (simpleEnchantment != null) {
+						final String loreLine = simpleEnchantment.getLore(entry.getValue());
+
+						if (loreLine != null && !loreLine.isEmpty())
+							colorLess.add(ChatColor.stripColor(Common.colorize(loreLine)));
+					}
+				}
+
+				for (final Map.Entry<Enchantment, Integer> entry : storedEnchants.entrySet()) {
+					final Enchantment storedEnchantment = entry.getKey();
+					final SimpleEnchantment simpleEnchantment = fromBukkit(storedEnchantment);
 
 					if (simpleEnchantment != null) {
 						final String loreLine = simpleEnchantment.getLore(entry.getValue());
@@ -657,6 +671,23 @@ public abstract class SimpleEnchantment implements Listener {
 
 					if (lore != null && !lore.isEmpty())
 						customEnchants.add(Common.colorize(FO_ENCHANT_PREFIX + lore));
+				}
+			}
+
+			if (Remain.hasItemMeta() && item.hasItemMeta()) {
+				ItemMeta meta = item.getItemMeta();
+				if (meta instanceof EnchantmentStorageMeta) {
+					for (final Map.Entry<Enchantment, Integer> entry : ((EnchantmentStorageMeta) meta).getStoredEnchants().entrySet()) {
+						final Enchantment enchantment = entry.getKey();
+						final SimpleEnchantment simpleEnchantment = fromBukkit(enchantment);
+
+						if (simpleEnchantment != null) {
+							final String lore = simpleEnchantment.getLore(entry.getValue());
+
+							if (lore != null && !lore.isEmpty())
+								customEnchants.add(Common.colorize(FO_ENCHANT_PREFIX + lore));
+						}
+					}
 				}
 			}
 

--- a/src/main/java/org/mineacademy/fo/enchant/SimpleEnchantment.java
+++ b/src/main/java/org/mineacademy/fo/enchant/SimpleEnchantment.java
@@ -589,7 +589,7 @@ public abstract class SimpleEnchantment implements Listener {
 		if (meta != null && meta.hasLore()) {
 			Map<Enchantment, Integer> enchants = item.getEnchantments();
 			Map<Enchantment, Integer> storedEnchants = meta instanceof EnchantmentStorageMeta ? ((EnchantmentStorageMeta) meta).getStoredEnchants() : null;
-			if (enchants.isEmpty() && storedEnchants == null && !storedEnchants.isEmpty())
+			if (enchants.isEmpty() && (storedEnchants == null || storedEnchants.isEmpty()))
 				return null;
 
 			final List<String> lore = meta.getLore();

--- a/src/main/java/org/mineacademy/fo/menu/model/ItemCreator.java
+++ b/src/main/java/org/mineacademy/fo/menu/model/ItemCreator.java
@@ -795,8 +795,6 @@ public final class ItemCreator {
 		// From now on we have to re-set the item
 		//
 
-		// Apply custom enchantment lores
-		compiledItem = Common.getOrDefault(SimpleEnchantment.addEnchantmentLores(compiledItem), compiledItem);
 
 		// 1.7.10 hack to add glow, requires no enchants
 		if (this.glow && MinecraftVersion.equals(V.v1_7) && (this.enchants == null || this.enchants.isEmpty())) {

--- a/src/main/java/org/mineacademy/fo/plugin/FoundationListener.java
+++ b/src/main/java/org/mineacademy/fo/plugin/FoundationListener.java
@@ -8,6 +8,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.PrepareAnvilEvent;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
@@ -25,6 +26,7 @@ import org.mineacademy.fo.model.HookManager;
 import org.mineacademy.fo.model.SimpleComponent;
 import org.mineacademy.fo.model.SimpleScoreboard;
 import org.mineacademy.fo.model.SpigotUpdater;
+import org.mineacademy.fo.remain.CompMaterial;
 import org.mineacademy.fo.settings.SimpleLocalization;
 
 /**
@@ -190,5 +192,17 @@ final class FoundationListener implements Listener {
 				player.setMetadata("vanished", new FixedMetadataValue(plugin, true));
 			}
 		}
+	}
+
+	@EventHandler(priority = EventPriority.HIGH)
+	public void onAnvilPrepareItem(PrepareAnvilEvent e) {
+		// A Weird visual bug where the anvil displays none
+		// tested on 1.20.4 -> If you:
+		// 1. Put an undamaged item with custom enchantment
+		// 2. Put another item with a custom enchantment By using a shift click (Or swapping items by picking it up)
+		// the anvil output flashes then empties
+		if (HookManager.isProtocolLibLoaded() && e.getResult() != null && !CompMaterial.isAir(e.getResult().getType()))
+			Bukkit.getScheduler().runTask(SimplePlugin.getInstance(), () -> ((Player) e.getViewers().getFirst())
+					.updateInventory());
 	}
 }

--- a/src/main/java/org/mineacademy/fo/plugin/FoundationPacketListener.java
+++ b/src/main/java/org/mineacademy/fo/plugin/FoundationPacketListener.java
@@ -72,13 +72,13 @@ final class FoundationPacketListener extends PacketListener {
 					int size = itemStacks.size();
 					for (int j = 0; j < size; j++) {
 
-						ItemStack itemStack = itemStacks.get(j);
-						if (itemStack != null && !itemStack.getType().isAir()) {
-							itemStack = SimpleEnchantment.addEnchantmentLores(itemStack);
-							if (itemStack == null)
+						ItemStack item = itemStacks.get(j);
+						if (item != null && !item.getType().isAir()) {
+							item = SimpleEnchantment.addEnchantmentLores(item);
+							if (item == null)
 								continue;
 
-							itemStacks.set(j, itemStack);
+							itemStacks.set(j, item);
 							changed = true;
 						}
 					}
@@ -96,13 +96,13 @@ final class FoundationPacketListener extends PacketListener {
 					boolean changed = false;
 
 					for (int j = 0; j < itemStacks.length; j++) {
-						ItemStack itemStack = itemStacks[j];
-						if (itemStack != null && !CompMaterial.isAir(itemStack.getType())) {
-							itemStack = SimpleEnchantment.addEnchantmentLores(itemStack);
-							if (itemStack == null)
+						ItemStack item = itemStacks[j];
+						if (item != null && !CompMaterial.isAir(item.getType())) {
+							item = SimpleEnchantment.addEnchantmentLores(item);
+							if (item == null)
 								continue;
 
-							itemStacks[j] = itemStack;
+							itemStacks[j] = item;
 							changed = true;
 						}
 					}

--- a/src/main/java/org/mineacademy/fo/plugin/FoundationPacketListener.java
+++ b/src/main/java/org/mineacademy/fo/plugin/FoundationPacketListener.java
@@ -1,11 +1,13 @@
 package org.mineacademy.fo.plugin;
 
+import com.comphenix.protocol.events.PacketContainer;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Sign;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.MerchantRecipe;
 import org.bukkit.metadata.MetadataValue;
 import org.mineacademy.fo.constants.FoConstants;
 import org.mineacademy.fo.enchant.SimpleEnchantment;
@@ -22,6 +24,9 @@ import com.comphenix.protocol.wrappers.WrappedChatComponent;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Listens to and intercepts packets using Foundation inbuilt features
@@ -53,6 +58,78 @@ final class FoundationPacketListener extends PacketListener {
 				if (item != null)
 					itemModifier.write(0, item);
 			}
+		});
+
+		this.addSendingListener(PacketType.Play.Server.WINDOW_ITEMS, event -> {
+			final PacketContainer packet = event.getPacket();
+
+			// for older versions, this is not needed because I believe they use an array
+			final StructureModifier<List<ItemStack>> itemListModifier = packet.getItemListModifier();
+			for (int i = 0; i < itemListModifier.size(); i++) {
+				List<ItemStack> itemStacks = itemListModifier.read(i);
+				if (itemStacks != null) {
+					boolean changed = false;
+					int size = itemStacks.size();
+					for (int j = 0; j < size; j++) {
+
+						ItemStack itemStack = itemStacks.get(j);
+						if (itemStack != null && !itemStack.getType().isAir()) {
+							itemStack = SimpleEnchantment.addEnchantmentLores(itemStack);
+							if (itemStack == null)
+								continue;
+
+							itemStacks.set(j, itemStack);
+							changed = true;
+						}
+					}
+					if (changed)
+						itemListModifier.write(i, itemStacks);
+				}
+			}
+
+			// Not needed for 1.13+ since they changed it to a list according to someone on the spigot forum
+			// Though, why not
+			final StructureModifier<ItemStack[]> itemArrayModifier = packet.getItemArrayModifier();
+			for (int i = 0; i < itemArrayModifier.size(); i++) {
+				ItemStack[] itemStacks = itemArrayModifier.read(i);
+				if (itemStacks != null) {
+					boolean changed = false;
+
+					for (int j = 0; j < itemStacks.length; j++) {
+						ItemStack itemStack = itemStacks[j];
+						if (itemStack != null && !CompMaterial.isAir(itemStack.getType())) {
+							itemStack = SimpleEnchantment.addEnchantmentLores(itemStack);
+							if (itemStack == null)
+								continue;
+
+							itemStacks[j] = itemStack;
+							changed = true;
+						}
+					}
+					if (changed)
+						itemArrayModifier.write(i, itemStacks);
+				}
+			}
+		});
+
+		this.addSendingListener(PacketType.Play.Server.OPEN_WINDOW_MERCHANT, event -> {
+			PacketContainer packet = event.getPacket();
+			List<MerchantRecipe> ls = packet.getMerchantRecipeLists().read(0);
+			for (int i = 0; i < ls.size(); i++) {
+				MerchantRecipe recipe = ls.get(i);
+				ItemStack item = recipe.getResult();
+				if (!CompMaterial.isAir(item.getType())) {
+					item = SimpleEnchantment.addEnchantmentLores(item);
+					if (item == null) {
+						continue;
+					}
+
+					MerchantRecipe newRecipe = new MerchantRecipe(item, recipe.getUses(), recipe.getMaxUses(), recipe.hasExperienceReward(), recipe.getVillagerExperience(), recipe.getPriceMultiplier());
+					newRecipe.setIngredients(recipe.getIngredients());
+					ls.set(i, newRecipe);
+				}
+			}
+			packet.getMerchantRecipeLists().write(0, ls);
 		});
 
 		// "Fix" a Folia bug preventing Conversation API from working properly


### PR DESCRIPTION
Fixes https://github.com/kangarko/Foundation/issues/310 & https://github.com/kangarko/Foundation/issues/302

Whats being done in this pr:
1. Injecting enchantment lore into `WINDOW_ITEMS` to fix enchantments not appearing since `WINDOW_ITEMS` packet isnt intercepted hence no fake lore 
2. Injecting enchantment lore into villagers' trade menus
3. remove our fake lore in `SET_CREATIVE_SLOT` packet, reason: Normally this packet is used to let clients create items in the server, due to its implementation, If a client opens inventory or tries to clone a custom enchanted item, the client normally sends the lore it thinks the item has (Our fake lore is included) which forces the server to make an item with said lore thus making it permanent (Not intended)
4. Show custom enchants in enchanted books (Inv, trade menus)

BTW for the third point, Its "visually buggy" comment is coming from the fact if you try to upgrade the item, it will still have the lower level lore
``` 
BlackNova III
BlackNova II
BlackNova I
```

As a side note, i dont know if we should/how to short-circuit the listeners related to custom enchantments if devs arent using foundation simple enchants
Another note, I havent checked if in older versions packet handling/fields are different, Other than the fact that versions older than 1.13, use Arrays instead of Lists but im not really 100% sure

Tested on 1.20.4 both spigot & paper
Spigot: 
![image](https://github.com/user-attachments/assets/934820b9-8ac8-402c-bc1d-2b979a082b6b)

Paper: 
![image](https://github.com/user-attachments/assets/abb7c2c2-7810-4ca4-a2c5-446189297c7b)

