### PR TITLE
Add 1.21 to the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ We aim to provide broad compatibility layer enabling the below Minecraft version
 - 1.7.10
 - 1.8.8
 - 1.9.x, 1.10.x, 1.11.x, 1.12.x
-- 1.13.x, 1.14.x, 1.15.x, 1.16.x, 1.17.x, 1.18.x, 1.19.x, 1.20.x
+- 1.13.x, 1.14.x, 1.15.x, 1.16.x, 1.17.x, 1.18.x, 1.19.x, 1.20.x, 1.21.x
 - We continously update for newer versions but sometimes forget to update it here, but it does not mean that the library is incompatible!
 
 Foundation works on Bukkit, Spigot, Paper and as of recently also Folia (see the Wiki).


### PR DESCRIPTION
Foundation supports 1.21, but it isn't in the readme file