### PR TITLE
fix: prefix is not bold at question and announce messages

### DIFF
--- a/src/main/java/org/mineacademy/fo/Messenger.java
+++ b/src/main/java/org/mineacademy/fo/Messenger.java
@@ -54,14 +54,14 @@ public class Messenger {
 	 */
 	@Setter
 	@Getter
-	private String questionPrefix = "&8&l[&a&l?&l&8]&7 ";
+	private String questionPrefix = "&8&l[&a&l?&l&8&l]&7 ";
 
 	/**
 	 * The prefix send while sending announcements
 	 */
 	@Setter
 	@Getter
-	private String announcePrefix = "&8&l[&5&l!&l&8]&d ";
+	private String announcePrefix = "&8&l[&5&l!&l&8&l]&d ";
 
 	/**
 	 * Send a message prepended with the {@link #getInfoPrefix()}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e67db5b2-0848-4e71-804e-2d0e31893f34)

The `]` bracket to close the prefix is not bold for a question and for an announcement.