### PR TITLE
Fix: not being able to hook into modern Faction plugins

### DIFF
--- a/foundation-bukkit/src/main/java/org/mineacademy/fo/model/HookManager.java
+++ b/foundation-bukkit/src/main/java/org/mineacademy/fo/model/HookManager.java
@@ -203,7 +203,8 @@ public final class HookManager {
 
 			if (ver.startsWith("1.6") || main.contains("FactionsUUIDAPIProxy"))
 				factionsHook = new FactionsUUID();
-			else if (ver.startsWith("2.")) {
+			// Condition commented due to blocking hooks with modern Factions plugins
+			else /*if (ver.startsWith("2."))*/ {
 				Class<?> mplayer = null;
 
 				try {


### PR DESCRIPTION
Plugin was only hooking into `FactionsUUID` or other Factions plugins which versions started with `"2."`.
Some modern Factions plugins were not being recognized.

Since the fail scenario is properly handled, I dont think it is a problem to try to hook into any Factions plugin.

_**PS:** verification for FactionsUUID still the same._

This issue came from ChatControl:
https://github.com/kangarko/ChatControl/issues/3179