### PR TITLE
Fix: closing tags appearing on chat if message ended with '\' (Issue #3211)

### DIFF
--- a/foundation-core/src/main/java/org/mineacademy/fo/model/SimpleComponent.java
+++ b/foundation-core/src/main/java/org/mineacademy/fo/model/SimpleComponent.java
@@ -996,8 +996,7 @@ public final class SimpleComponent implements ConfigSerializable {
 		try {
 			// Correct MiniMessage potentially dangerous behavior where multiple backslashes will
 			// make the variable parse so we slash it to one.
-//			message = message.replaceAll("(\\\\){2,}(?=<)", "\\\\"); // Commented out as it was causing issues with closing mini tags.
-			message = message.replaceAll("(\\\\){2,}(?=<[^/])", "\\\\"); // New version, which only prevents the multiple backslashes on opening tags.
+			message = message.replaceAll("(\\\\){2,}(?=<[^/])", "\\\\"); // New RegExp normalizes backslashes before opening tags only
 
 			// See resetColors() below for explainer
 			mini = MINIMESSAGE_PARSER.deserialize(message.replace("<reset>", "<#180f0d>").replace("\\n", "\n"));

--- a/foundation-core/src/main/java/org/mineacademy/fo/model/SimpleComponent.java
+++ b/foundation-core/src/main/java/org/mineacademy/fo/model/SimpleComponent.java
@@ -996,7 +996,8 @@ public final class SimpleComponent implements ConfigSerializable {
 		try {
 			// Correct MiniMessage potentially dangerous behavior where multiple backslashes will
 			// make the variable parse so we slash it to one.
-			message = message.replaceAll("(\\\\){2,}(?=<)", "\\\\");
+//			message = message.replaceAll("(\\\\){2,}(?=<)", "\\\\"); // Commented out as it was causing issues with closing mini tags.
+			message = message.replaceAll("(\\\\){2,}(?=<[^/])", "\\\\"); // New version, which only prevents the multiple backslashes on opening tags.
 
 			// See resetColors() below for explainer
 			mini = MINIMESSAGE_PARSER.deserialize(message.replace("<reset>", "<#180f0d>").replace("\\n", "\n"));


### PR DESCRIPTION
When normalizing backslashes before any closing tag, it would cause the tag not to be processed and actually appear on the final message.
New RegExp normalizes backslashes before opening tags only.