### PR TITLE
Fix: ensure console commands are dispatched asynchronously when using Folia

### DIFF
--- a/foundation-bukkit/src/main/java/org/mineacademy/fo/platform/BukkitPlatform.java
+++ b/foundation-bukkit/src/main/java/org/mineacademy/fo/platform/BukkitPlatform.java
@@ -536,7 +536,7 @@ final class BukkitPlatform extends FoundationPlatform {
 
 	@Override
 	protected void dispatchConsoleCommand0(final String command) {
-		if (Bukkit.isPrimaryThread())
+		if (Bukkit.isPrimaryThread() && !Remain.isFolia())
 			Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command);
 		else
 			Platform.runTask(0, () -> Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command));


### PR DESCRIPTION
Related to Issue [ChatControl#3227](https://github.com/kangarko/ChatControl/issues/3227)

The method `dispatchConsoleCommand0` was being invoked asynchronously, which led to an `IllegalStateException` when attempting to forward commands, for example.

