### PR TITLE
Fix: typo in decoration name: "underline" instead of "underlined"

### DIFF
--- a/foundation-core/src/main/java/org/mineacademy/fo/model/CompChatColor.java
+++ b/foundation-core/src/main/java/org/mineacademy/fo/model/CompChatColor.java
@@ -196,7 +196,7 @@ public final class CompChatColor implements TextColor, ConfigStringSerializable 
 	/**
 	 * Makes the text appear underlined.
 	 */
-	public static final CompChatColor UNDERLINE = new CompChatColor('n', "underline");
+	public static final CompChatColor UNDERLINE = new CompChatColor('n', "underlined");
 
 	/**
 	 * Makes the text italic.


### PR DESCRIPTION
[ChatControl#3239](https://github.com/kangarko/ChatControl/issues/3239)