### PR TITLE
New: add support to custom sounds

### DIFF
--- a/foundation-bukkit/src/main/java/org/mineacademy/fo/model/SimpleSound.java
+++ b/foundation-bukkit/src/main/java/org/mineacademy/fo/model/SimpleSound.java
@@ -48,12 +48,17 @@ public final class SimpleSound implements ConfigStringSerializable {
 	 */
 	private boolean enabled = true;
 
+	/**
+	 * Is this sound custom?
+	 */
+	private String customSoundName;
+
 	private SimpleSound(final CompSound sound, final float volume, final float pitch) {
-		this(sound, volume, pitch, false, true);
+		this(sound, volume, pitch, false, true, null);
 	}
 
 	private SimpleSound(final CompSound sound, final float volume) {
-		this(sound, volume, 1.0F, true, true);
+		this(sound, volume, 1.0F, true, true, null);
 	}
 
 	/**
@@ -84,10 +89,14 @@ public final class SimpleSound implements ConfigStringSerializable {
 	 */
 	public void play(final Player player) {
 		if (this.enabled) {
-			ValidCore.checkNotNull(this.sound);
 
 			try {
-				player.playSound(player.getLocation(), this.sound.getSound(), this.volume, this.getPitch());
+				if(this.customSoundName != null)
+					player.playSound(player.getLocation(), this.customSoundName, this.volume, this.getPitch());
+				else {
+					ValidCore.checkNotNull(this.sound);
+					player.playSound(player.getLocation(), this.sound.getSound(), this.volume, this.getPitch());
+				}
 			} catch (final NoSuchMethodError err) {
 				// Legacy MC
 			}
@@ -101,10 +110,14 @@ public final class SimpleSound implements ConfigStringSerializable {
 	 */
 	public void play(final Location location) {
 		if (this.enabled) {
-			ValidCore.checkNotNull(this.sound);
 
 			try {
-				location.getWorld().playSound(location, this.sound.getSound(), this.volume, this.getPitch());
+				if(this.customSoundName != null)
+					location.getWorld().playSound(location, this.customSoundName, this.volume, this.getPitch());
+				else {
+					ValidCore.checkNotNull(this.sound);
+					location.getWorld().playSound(location, this.sound.getSound(), this.volume, this.getPitch());
+				}
 			} catch (final NoSuchMethodError err) {
 				// Legacy MC
 			}
@@ -125,7 +138,7 @@ public final class SimpleSound implements ConfigStringSerializable {
 	 */
 	@Override
 	public String serialize() {
-		return this.enabled ? this.sound + " " + this.volume + " " + (this.randomPitch ? "random" : this.pitch) : "none";
+		return this.enabled ? (this.customSoundName != null ? "custom:" + this.customSoundName : this.sound) + " " + this.volume + " " + (this.randomPitch ? "random" : this.pitch) : "none";
 	}
 
 	/**
@@ -148,17 +161,37 @@ public final class SimpleSound implements ConfigStringSerializable {
 	 */
 	public static SimpleSound fromString(final String line) {
 		if ("none".equals(line) || "".equals(line))
-			return new SimpleSound(CompSound.UI_BUTTON_CLICK, 0.0F, 1.0F, false, false);
+			return new SimpleSound(CompSound.UI_BUTTON_CLICK, 0.0F, 1.0F, false, false, null);
 
 		final String[] values = line.contains(", ") ? line.split(", ") : line.split(" ");
-		final CompSound compSound = CompSound.fromName(values[0]);
+
+		final String soundNameRaw = values[0].toLowerCase();
+
+		// Check if the sound is custom
+		final boolean customSound = soundNameRaw.startsWith("custom:");
+
+		// If the sound is custom, we strip the "custom:" prefix
+		String soundName = customSound ? soundNameRaw.substring("custom:".length()) : soundNameRaw.toUpperCase();
+
+		// If the sound is custom and does not start with "minecraft:", we prefix it with "minecraft:"
+		if(customSound && !soundName.startsWith("minecraft:"))
+			soundName = "minecraft:" + soundName; // Ensure custom sounds are prefixed with minecraft:
+
+		// If the sound is not custom, we try to get the CompSound from the name
+		CompSound compSound = customSound ? null : CompSound.fromName(soundName);
+
+		if (compSound == null && !customSound)
+			throw new FoException("Sound '" + values[0] + "' does not exists (in your Minecraft version " + MinecraftVersion.getFullVersion() + ")! Pick one from mineacademy.org/sounds", false);
+
+		// If the sound is custom and does not exist, we set it to a dummy sound
+		else if(compSound == null)
+			compSound = CompSound.UI_BUTTON_CLICK; // Dummy sound for custom sounds
 
 		final SimpleSound sound = new SimpleSound();
 
-		if (compSound == null)
-			throw new FoException("Sound '" + values[0] + "' does not exists (in your Minecraft version " + MinecraftVersion.getFullVersion() + ")! Pick one from mineacademy.org/sounds", false);
-
 		sound.sound = compSound;
+		if(customSound)
+			sound.customSoundName = soundName;
 
 		if (values.length == 1) {
 			sound.volume = 1F;


### PR DESCRIPTION
(Issue [ChatControl#3237](https://github.com/kangarko/ChatControl/issues/3237))

If the sound name starts with `custom:`, then we store it in a string and play it as a custom sound. If not, works the same way as before.