### PR TITLE
Fix: prevent <click> and <hover> tags from being processed in variable values

### DIFF
--- a/foundation-core/src/main/java/org/mineacademy/fo/model/Variable.java
+++ b/foundation-core/src/main/java/org/mineacademy/fo/model/Variable.java
@@ -38,6 +38,12 @@ public final class Variable extends YamlConfig {
 	private static final Pattern VALID_KEY_PATTERN = Pattern.compile("^\\w+$");
 
 	/**
+	 * Pattern to identify potentially dangerous mini tags inside variables
+	 */
+	private static final Pattern BLACKLISTED_TAGS =
+			Pattern.compile("<(/?)(click|hover)([^>]*)>", Pattern.CASE_INSENSITIVE);
+
+	/**
 	 * A list of all loaded variables
 	 */
 	private static final ConfigItems<Variable> loadedVariables = ConfigItems.fromFolder("variables", Variable.class);
@@ -491,10 +497,14 @@ public final class Variable extends YamlConfig {
 		return variablesByKeys.keySet();
 	}
 
-	private static final Pattern BLACKLISTED_TAGS =
-			Pattern.compile("<(/?)(click|hover)([^>]*)>", Pattern.CASE_INSENSITIVE);
-
-	public static String stripBlacklistedTags(String text) {
+	/**
+	 * Helper method to strip the BLACKLISTED_TAGS from variables
+	 * since those may contain malicious user input.
+	 *
+	 * @param text
+	 * @return
+	 */
+	private static String stripBlacklistedTags(String text) {
 		if (text == null) return null;
 
 		return BLACKLISTED_TAGS.matcher(text).replaceAll("");

--- a/foundation-core/src/main/java/org/mineacademy/fo/model/Variable.java
+++ b/foundation-core/src/main/java/org/mineacademy/fo/model/Variable.java
@@ -305,7 +305,7 @@ public final class Variable extends YamlConfig {
 			if (value == null || value.isEmpty() || "null".equals(value))
 				return SimpleComponent.empty();
 
-			SimpleComponent component = SimpleComponent.fromMiniAmpersand(stripBlacklistedTags(value));
+			SimpleComponent component = SimpleComponent.fromMiniAmpersand(this.type.equals(Type.MESSAGE) ? stripBlacklistedTags(value) : value);
 
 			if (!ValidCore.isNullOrEmpty(this.hoverText))
 				component = component.onHoverLegacy(variables.replaceLegacyArray(CommonCore.toArray(this.hoverText)));

--- a/foundation-core/src/main/java/org/mineacademy/fo/model/Variable.java
+++ b/foundation-core/src/main/java/org/mineacademy/fo/model/Variable.java
@@ -299,7 +299,7 @@ public final class Variable extends YamlConfig {
 			if (value == null || value.isEmpty() || "null".equals(value))
 				return SimpleComponent.empty();
 
-			SimpleComponent component = SimpleComponent.fromMiniAmpersand(value);
+			SimpleComponent component = SimpleComponent.fromMiniAmpersand(stripBlacklistedTags(value));
 
 			if (!ValidCore.isNullOrEmpty(this.hoverText))
 				component = component.onHoverLegacy(variables.replaceLegacyArray(CommonCore.toArray(this.hoverText)));
@@ -489,6 +489,15 @@ public final class Variable extends YamlConfig {
 	 */
 	public static Set<String> getVariableKeyNames() {
 		return variablesByKeys.keySet();
+	}
+
+	private static final Pattern BLACKLISTED_TAGS =
+			Pattern.compile("<(/?)(click|hover)([^>]*)>", Pattern.CASE_INSENSITIVE);
+
+	public static String stripBlacklistedTags(String text) {
+		if (text == null) return null;
+
+		return BLACKLISTED_TAGS.matcher(text).replaceAll("");
 	}
 
 	// ------–------–------–------–------–------–------–------–------–------–------–------–


### PR DESCRIPTION
(Issue [ChatControl#3278](https://github.com/kangarko/ChatControl/issues/3278))

Since variables may contain user provided input and those could be malicious.

Example: in [item] variable, if the item name contained <click:run_command:"/suicide">, the command would be executed when someone clicked.

Solution was to remove <click> and <hover> tags from the value returned by the variable script.