### PR TITLE
Fix: prevent legacy color codes from being parsed inside links

### DIFF
--- a/foundation-core/src/main/java/org/mineacademy/fo/ChatUtil.java
+++ b/foundation-core/src/main/java/org/mineacademy/fo/ChatUtil.java
@@ -542,7 +542,10 @@ public final class ChatUtil {
 		final StringBuilder result = new StringBuilder();
 		final String[] words = message.split("\\s+");
 
-		for (final String word : words) {
+		for (String word : words) {
+			final String color = word.startsWith("&") && word.length() > 2 ? word.substring(0, 2) : "";
+			if(!color.isEmpty())
+				word = word.substring(2);
 			final Matcher matcher = CLICKABLE_DOMAIN_PATTERN.matcher(word);
 			if (matcher.matches()) {
 				final String protocol = matcher.group(1) != null ? matcher.group(1) : "https";
@@ -550,9 +553,10 @@ public final class ChatUtil {
 				final String path = matcher.group(3) != null ? matcher.group(3) : "";
 				final String fullUrl = protocol + "://" + domain + path;
 
-				result.append(String.format("<click:open_url:'%s'>%s</click> ", fullUrl, word));
+				String format = String.format("<click:open_url:'%s'>%s</click> ", fullUrl, CompChatColor.convertLegacyToMini(color, true).trim() + word);
+				result.append(format);
 			} else {
-				result.append(word).append(" ");
+				result.append(color).append(word).append(" ");
 			}
 		}
 

--- a/foundation-core/src/main/java/org/mineacademy/fo/model/CompChatColor.java
+++ b/foundation-core/src/main/java/org/mineacademy/fo/model/CompChatColor.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.mineacademy.fo.ChatUtil;
@@ -825,44 +826,70 @@ public final class CompChatColor implements TextColor, ConfigStringSerializable 
 	public static String convertLegacyToMini(final String message, final boolean supportAmpersand) {
 		final StringBuilder result = new StringBuilder();
 
-		for (int i = 0; i < message.length(); i++) {
+		final Pattern DOMAIN_INSIDE_MINI_TAG_PATTERN = Pattern.compile("<.*[a-zA-Z0-9\\-.*]+\\s?(\\.|\\*|dot|\\(dot\\)|-|\\(\\*\\)|;|:|,)\\s?(c(| +)o(| +)m|o(| +)r(| +)g|n(| +)e(| +)t|(?<! )c(| +)z|(?<! )c(| +)o|(?<! )u(| +)k|(?<! )s(| +)k|b(| +)i(| +)z|(?<! )m(| +)o(| +)b(| +)i|(?<! )x(| +)x(| +)x|(?<! )e(| +)u|(?<! )m(| +)e|(?<! )i(| +)o|(?<! )o(| +)n(| +)l(| +)i(| +)n(| +)e|(?<! )x(| +)y(| +)z|(?<! )f(| +)r|(?<! )b(| +)e|(?<! )d(| +)e|(?<! )c(| +)a|(?<! )a(| +)l|(?<! )a(| +)i|(?<! )d(| +)e(| +)v|(?<! )a(| +)p(| +)p|(?<! )i(| +)n|(?<! )i(| +)s|(?<! )g(| +)g|(?<! )t(| +)o|(?<! )p(| +)h|(?<! )n(| +)l|(?<! )i(| +)d|(?<! )i(| +)n(| +)c|(?<! )u(| +)s|(?<! )p(| +)w|(?<! )p(| +)r(| +)o|(?<! )t(| +)v|(?<! )c(| +)x|(?<! )m(| +)x|(?<! )f(| +)m|(?<! )c(| +)c|(?<! )v(| +)i(| +)p|(?<! )f(| +)u(| +)n|(?<! )i(| +)c(| +)u)\\b"),
+				GENERIC_DOMAIN_PATTERN = Pattern.compile("[a-zA-Z0-9\\-.*]+\\s?(\\.|\\*|dot|\\(dot\\)|-|\\(\\*\\)|;|:|,)\\s?(c(| +)o(| +)m|o(| +)r(| +)g|n(| +)e(| +)t|(?<! )c(| +)z|(?<! )c(| +)o|(?<! )u(| +)k|(?<! )s(| +)k|b(| +)i(| +)z|(?<! )m(| +)o(| +)b(| +)i|(?<! )x(| +)x(| +)x|(?<! )e(| +)u|(?<! )m(| +)e|(?<! )i(| +)o|(?<! )o(| +)n(| +)l(| +)i(| +)n(| +)e|(?<! )x(| +)y(| +)z|(?<! )f(| +)r|(?<! )b(| +)e|(?<! )d(| +)e|(?<! )c(| +)a|(?<! )a(| +)l|(?<! )a(| +)i|(?<! )d(| +)e(| +)v|(?<! )a(| +)p(| +)p|(?<! )i(| +)n|(?<! )i(| +)s|(?<! )g(| +)g|(?<! )t(| +)o|(?<! )p(| +)h|(?<! )n(| +)l|(?<! )i(| +)d|(?<! )i(| +)n(| +)c|(?<! )u(| +)s|(?<! )p(| +)w|(?<! )p(| +)r(| +)o|(?<! )t(| +)v|(?<! )c(| +)x|(?<! )m(| +)x|(?<! )f(| +)m|(?<! )c(| +)c|(?<! )v(| +)i(| +)p|(?<! )f(| +)u(| +)n|(?<! )i(| +)c(| +)u)\\b"),
+				COLOR_CODE_PATTERN = Pattern.compile("(?i)(?:[§&][0-9a-fk-or])+");
 
-			// Support §x§R§R§G§G§B§B hex colors
-			if (i + 13 < message.length() && message.charAt(i) == '§' && message.charAt(i + 1) == 'x') {
-				final StringBuilder hex = new StringBuilder("#");
-				boolean isValidHexSequence = true;
+		for(String part : message.split(" ")) {
+			if(DOMAIN_INSIDE_MINI_TAG_PATTERN.matcher(part).find()) {
+				result.append(part).append(" ");
+				continue;
+			} else if(GENERIC_DOMAIN_PATTERN.matcher(part).find()) {
+				if(String.valueOf(part.charAt(0)).matches("[§&]")) {
+					final Matcher matcher = COLOR_CODE_PATTERN.matcher(part);
+					String color = null;
+					while(matcher.find() && (color == null || !part.startsWith(color))) {
+						color = matcher.group();
+					}
+					if(color != null)
+						result.append(CompChatColor.convertLegacyToMini(color, true)).append(part.replaceFirst(color, "")).append(" ");
+				} else {
+					result.append(part).append(" ");
+                }
+                continue;
+            }
 
-				for (int j = 2; j <= 12; j += 2) {
-					if (message.charAt(i + j) == '§')
-						hex.append(message.charAt(i + j + 1));
+			for (int i = 0; i < part.length(); i++) {
 
-					else {
-						isValidHexSequence = false;
+				// Support §x§R§R§G§G§B§B hex colors
+				if (i + 13 < part.length() && part.charAt(i) == '§' && part.charAt(i + 1) == 'x') {
+					final StringBuilder hex = new StringBuilder("#");
+					boolean isValidHexSequence = true;
 
-						break;
+					for (int j = 2; j <= 12; j += 2) {
+						if (part.charAt(i + j) == '§')
+							hex.append(part.charAt(i + j + 1));
+
+						else {
+							isValidHexSequence = false;
+
+							break;
+						}
+					}
+
+					if (isValidHexSequence) {
+						result.append('<').append(hex).append('>');
+						i += 13; // Skip the entire §x§R§R§G§G§B§B sequence
+
+						continue;
 					}
 				}
 
-				if (isValidHexSequence) {
-					result.append('<').append(hex).append('>');
-					i += 13; // Skip the entire §x§R§R§G§G§B§B sequence
+				if (i + 1 < part.length() && ((part.charAt(i) == '&' && supportAmpersand) || part.charAt(i) == '§')) {
+					final String code = part.substring(i, i + 2);
 
-					continue;
+					if (LEGACY_TO_MINI.containsKey(code)) {
+						result.append(LEGACY_TO_MINI.get(code));
+						i++;
+
+						continue;
+					}
 				}
+
+				result.append(part.charAt(i));
 			}
-
-			if (i + 1 < message.length() && ((message.charAt(i) == '&' && supportAmpersand) || message.charAt(i) == '§')) {
-				final String code = message.substring(i, i + 2);
-
-				if (LEGACY_TO_MINI.containsKey(code)) {
-					result.append(LEGACY_TO_MINI.get(code));
-					i++;
-
-					continue;
-				}
-			}
-
-			result.append(message.charAt(i));
+			if(!message.endsWith(part))
+				result.append(" ");
 		}
 
 		return result.toString();


### PR DESCRIPTION
(Issue [ChatControl#3274](https://github.com/kangarko/ChatControl/issues/3274))

Causes error on newer server versions