### PR TITLE
Fix: overhaul of 'color inside links' solution for better consistency and performance improvement

### DIFF
--- a/foundation-core/src/main/java/org/mineacademy/fo/model/CompChatColor.java
+++ b/foundation-core/src/main/java/org/mineacademy/fo/model/CompChatColor.java
@@ -35,8 +35,7 @@ public final class CompChatColor implements TextColor, ConfigStringSerializable 
 	 * Patterns to identify domains inside and outside of Mini Tags to prevent converting "legacy color codes" inside links to mini tags
 	 * in convertLegacyToMini() method.
 	 */
-	private static final Pattern DOMAIN_INSIDE_MINI_TAG_PATTERN = Pattern.compile("<.*[a-zA-Z0-9\\-.*]+\\s?(\\.|\\*|dot|\\(dot\\)|-|\\(\\*\\)|;|:|,)\\s?(c(| +)o(| +)m|o(| +)r(| +)g|n(| +)e(| +)t|(?<! )c(| +)z|(?<! )c(| +)o|(?<! )u(| +)k|(?<! )s(| +)k|b(| +)i(| +)z|(?<! )m(| +)o(| +)b(| +)i|(?<! )x(| +)x(| +)x|(?<! )e(| +)u|(?<! )m(| +)e|(?<! )i(| +)o|(?<! )o(| +)n(| +)l(| +)i(| +)n(| +)e|(?<! )x(| +)y(| +)z|(?<! )f(| +)r|(?<! )b(| +)e|(?<! )d(| +)e|(?<! )c(| +)a|(?<! )a(| +)l|(?<! )a(| +)i|(?<! )d(| +)e(| +)v|(?<! )a(| +)p(| +)p|(?<! )i(| +)n|(?<! )i(| +)s|(?<! )g(| +)g|(?<! )t(| +)o|(?<! )p(| +)h|(?<! )n(| +)l|(?<! )i(| +)d|(?<! )i(| +)n(| +)c|(?<! )u(| +)s|(?<! )p(| +)w|(?<! )p(| +)r(| +)o|(?<! )t(| +)v|(?<! )c(| +)x|(?<! )m(| +)x|(?<! )f(| +)m|(?<! )c(| +)c|(?<! )v(| +)i(| +)p|(?<! )f(| +)u(| +)n|(?<! )i(| +)c(| +)u)\\b"),
-			GENERIC_DOMAIN_PATTERN = Pattern.compile("[a-zA-Z0-9\\-.*]+\\s?(\\.|\\*|dot|\\(dot\\)|-|\\(\\*\\)|;|:|,)\\s?(c(| +)o(| +)m|o(| +)r(| +)g|n(| +)e(| +)t|(?<! )c(| +)z|(?<! )c(| +)o|(?<! )u(| +)k|(?<! )s(| +)k|b(| +)i(| +)z|(?<! )m(| +)o(| +)b(| +)i|(?<! )x(| +)x(| +)x|(?<! )e(| +)u|(?<! )m(| +)e|(?<! )i(| +)o|(?<! )o(| +)n(| +)l(| +)i(| +)n(| +)e|(?<! )x(| +)y(| +)z|(?<! )f(| +)r|(?<! )b(| +)e|(?<! )d(| +)e|(?<! )c(| +)a|(?<! )a(| +)l|(?<! )a(| +)i|(?<! )d(| +)e(| +)v|(?<! )a(| +)p(| +)p|(?<! )i(| +)n|(?<! )i(| +)s|(?<! )g(| +)g|(?<! )t(| +)o|(?<! )p(| +)h|(?<! )n(| +)l|(?<! )i(| +)d|(?<! )i(| +)n(| +)c|(?<! )u(| +)s|(?<! )p(| +)w|(?<! )p(| +)r(| +)o|(?<! )t(| +)v|(?<! )c(| +)x|(?<! )m(| +)x|(?<! )f(| +)m|(?<! )c(| +)c|(?<! )v(| +)i(| +)p|(?<! )f(| +)u(| +)n|(?<! )i(| +)c(| +)u)\\b"),
+	private static final Pattern GENERIC_DOMAIN_PATTERN = Pattern.compile("[a-zA-Z0-9\\-.*]+\\s?(\\.|\\*|dot|\\(dot\\)|-|\\(\\*\\)|;|:|,)\\s?(c(| +)o(| +)m|o(| +)r(| +)g|n(| +)e(| +)t|(?<! )c(| +)z|(?<! )c(| +)o|(?<! )u(| +)k|(?<! )s(| +)k|b(| +)i(| +)z|(?<! )m(| +)o(| +)b(| +)i|(?<! )x(| +)x(| +)x|(?<! )e(| +)u|(?<! )m(| +)e|(?<! )i(| +)o|(?<! )o(| +)n(| +)l(| +)i(| +)n(| +)e|(?<! )x(| +)y(| +)z|(?<! )f(| +)r|(?<! )b(| +)e|(?<! )d(| +)e|(?<! )c(| +)a|(?<! )a(| +)l|(?<! )a(| +)i|(?<! )d(| +)e(| +)v|(?<! )a(| +)p(| +)p|(?<! )i(| +)n|(?<! )i(| +)s|(?<! )g(| +)g|(?<! )t(| +)o|(?<! )p(| +)h|(?<! )n(| +)l|(?<! )i(| +)d|(?<! )i(| +)n(| +)c|(?<! )u(| +)s|(?<! )p(| +)w|(?<! )p(| +)r(| +)o|(?<! )t(| +)v|(?<! )c(| +)x|(?<! )m(| +)x|(?<! )f(| +)m|(?<! )c(| +)c|(?<! )v(| +)i(| +)p|(?<! )f(| +)u(| +)n|(?<! )i(| +)c(| +)u)\\b"),
 			COLOR_CODE_PATTERN = Pattern.compile("(?i)(?:[§&][0-9a-fk-or])+");
 
 	/**
@@ -840,16 +839,16 @@ public final class CompChatColor implements TextColor, ConfigStringSerializable 
 		for (int idx = 0; idx < parts.length; idx++) {
 			final String part = parts[idx];
 
-			if (DOMAIN_INSIDE_MINI_TAG_PATTERN.matcher(part).find()) {
-				// Domain inside <click_url> tag, should be ignored
-				result.append(part);
-				if (idx < parts.length - 1) result.append(' ');
-				continue;
-			}
-
 			if (GENERIC_DOMAIN_PATTERN.matcher(part).find()) {
-				// Actual domain in the player message, should be sanitized and colors should be ignored
 
+				if(part.startsWith("<") && part.endsWith(">")) {
+					// Domain inside <click_url> tag, should be ignored
+					result.append(part);
+					if (idx < parts.length - 1) result.append(' ');
+					continue;
+				}
+
+				// Actual domain in the player message, should be sanitized and colors should be ignored
 				if (!part.isEmpty() && (part.charAt(0) == '§' || part.charAt(0) == '&')) {
 
 					// Domain has a color code at the start, so we need to color it properly :)

--- a/foundation-core/src/main/java/org/mineacademy/fo/model/CompChatColor.java
+++ b/foundation-core/src/main/java/org/mineacademy/fo/model/CompChatColor.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.mineacademy.fo.ChatUtil;
@@ -825,44 +826,85 @@ public final class CompChatColor implements TextColor, ConfigStringSerializable 
 	public static String convertLegacyToMini(final String message, final boolean supportAmpersand) {
 		final StringBuilder result = new StringBuilder();
 
-		for (int i = 0; i < message.length(); i++) {
+		final Pattern DOMAIN_INSIDE_MINI_TAG_PATTERN = Pattern.compile("<.*[a-zA-Z0-9\\-.*]+\\s?(\\.|\\*|dot|\\(dot\\)|-|\\(\\*\\)|;|:|,)\\s?(c(| +)o(| +)m|o(| +)r(| +)g|n(| +)e(| +)t|(?<! )c(| +)z|(?<! )c(| +)o|(?<! )u(| +)k|(?<! )s(| +)k|b(| +)i(| +)z|(?<! )m(| +)o(| +)b(| +)i|(?<! )x(| +)x(| +)x|(?<! )e(| +)u|(?<! )m(| +)e|(?<! )i(| +)o|(?<! )o(| +)n(| +)l(| +)i(| +)n(| +)e|(?<! )x(| +)y(| +)z|(?<! )f(| +)r|(?<! )b(| +)e|(?<! )d(| +)e|(?<! )c(| +)a|(?<! )a(| +)l|(?<! )a(| +)i|(?<! )d(| +)e(| +)v|(?<! )a(| +)p(| +)p|(?<! )i(| +)n|(?<! )i(| +)s|(?<! )g(| +)g|(?<! )t(| +)o|(?<! )p(| +)h|(?<! )n(| +)l|(?<! )i(| +)d|(?<! )i(| +)n(| +)c|(?<! )u(| +)s|(?<! )p(| +)w|(?<! )p(| +)r(| +)o|(?<! )t(| +)v|(?<! )c(| +)x|(?<! )m(| +)x|(?<! )f(| +)m|(?<! )c(| +)c|(?<! )v(| +)i(| +)p|(?<! )f(| +)u(| +)n|(?<! )i(| +)c(| +)u)\\b"),
+				GENERIC_DOMAIN_PATTERN = Pattern.compile("[a-zA-Z0-9\\-.*]+\\s?(\\.|\\*|dot|\\(dot\\)|-|\\(\\*\\)|;|:|,)\\s?(c(| +)o(| +)m|o(| +)r(| +)g|n(| +)e(| +)t|(?<! )c(| +)z|(?<! )c(| +)o|(?<! )u(| +)k|(?<! )s(| +)k|b(| +)i(| +)z|(?<! )m(| +)o(| +)b(| +)i|(?<! )x(| +)x(| +)x|(?<! )e(| +)u|(?<! )m(| +)e|(?<! )i(| +)o|(?<! )o(| +)n(| +)l(| +)i(| +)n(| +)e|(?<! )x(| +)y(| +)z|(?<! )f(| +)r|(?<! )b(| +)e|(?<! )d(| +)e|(?<! )c(| +)a|(?<! )a(| +)l|(?<! )a(| +)i|(?<! )d(| +)e(| +)v|(?<! )a(| +)p(| +)p|(?<! )i(| +)n|(?<! )i(| +)s|(?<! )g(| +)g|(?<! )t(| +)o|(?<! )p(| +)h|(?<! )n(| +)l|(?<! )i(| +)d|(?<! )i(| +)n(| +)c|(?<! )u(| +)s|(?<! )p(| +)w|(?<! )p(| +)r(| +)o|(?<! )t(| +)v|(?<! )c(| +)x|(?<! )m(| +)x|(?<! )f(| +)m|(?<! )c(| +)c|(?<! )v(| +)i(| +)p|(?<! )f(| +)u(| +)n|(?<! )i(| +)c(| +)u)\\b"),
+				COLOR_CODE_PATTERN = Pattern.compile("(?i)(?:[§&][0-9a-fk-or])+");
 
-			// Support §x§R§R§G§G§B§B hex colors
-			if (i + 13 < message.length() && message.charAt(i) == '§' && message.charAt(i + 1) == 'x') {
-				final StringBuilder hex = new StringBuilder("#");
-				boolean isValidHexSequence = true;
+		for (int idx = 0; idx < message.split(" ", -1).length; idx++) {
+			String part = message.split(" ", -1)[idx];
 
-				for (int j = 2; j <= 12; j += 2) {
-					if (message.charAt(i + j) == '§')
-						hex.append(message.charAt(i + j + 1));
+			// If it's empty, that means it was an extra space
+			if (part.isEmpty()) {
+				result.append(" ");
+				continue;
+			}
 
-					else {
-						isValidHexSequence = false;
+			if(DOMAIN_INSIDE_MINI_TAG_PATTERN.matcher(part).find()) {
+				result.append(part).append(" ");
+				continue;
 
-						break;
+			} else if(GENERIC_DOMAIN_PATTERN.matcher(part).find()) {
+				if(String.valueOf(part.charAt(0)).matches("[§&]")) {
+
+					final Matcher matcher = COLOR_CODE_PATTERN.matcher(part);
+					String color = null;
+
+					while(matcher.find() && (color == null || !part.startsWith(color))) {
+						color = matcher.group();
+					}
+
+					if(color != null)
+						result.append(CompChatColor.convertLegacyToMini(color, true)).append(part.replaceFirst(color, "")).append(" ");
+
+				} else result.append(part).append(" ");
+
+				continue;
+			}
+
+			for (int i = 0; i < part.length(); i++) {
+
+				// Support §x§R§R§G§G§B§B hex colors
+				if (i + 13 < part.length() && part.charAt(i) == '§' && part.charAt(i + 1) == 'x') {
+					final StringBuilder hex = new StringBuilder("#");
+					boolean isValidHexSequence = true;
+
+					for (int j = 2; j <= 12; j += 2) {
+						if (part.charAt(i + j) == '§')
+							hex.append(part.charAt(i + j + 1));
+
+						else {
+							isValidHexSequence = false;
+
+							break;
+						}
+					}
+
+					if (isValidHexSequence) {
+						result.append('<').append(hex).append('>');
+						i += 13; // Skip the entire §x§R§R§G§G§B§B sequence
+
+						continue;
 					}
 				}
 
-				if (isValidHexSequence) {
-					result.append('<').append(hex).append('>');
-					i += 13; // Skip the entire §x§R§R§G§G§B§B sequence
+				if (i + 1 < part.length() && ((part.charAt(i) == '&' && supportAmpersand) || part.charAt(i) == '§')) {
+					final String code = part.substring(i, i + 2);
 
-					continue;
+					if (LEGACY_TO_MINI.containsKey(code)) {
+						result.append(LEGACY_TO_MINI.get(code));
+						i++;
+
+						continue;
+					}
 				}
+
+				result.append(part.charAt(i));
 			}
 
-			if (i + 1 < message.length() && ((message.charAt(i) == '&' && supportAmpersand) || message.charAt(i) == '§')) {
-				final String code = message.substring(i, i + 2);
-
-				if (LEGACY_TO_MINI.containsKey(code)) {
-					result.append(LEGACY_TO_MINI.get(code));
-					i++;
-
-					continue;
-				}
+			// re-append the space except after the last part
+			if (idx < message.split(" ", -1).length - 1) {
+				result.append(" ");
 			}
-
-			result.append(message.charAt(i));
 		}
 
 		return result.toString();

--- a/foundation-core/src/main/java/org/mineacademy/fo/model/CompChatColor.java
+++ b/foundation-core/src/main/java/org/mineacademy/fo/model/CompChatColor.java
@@ -1097,7 +1097,7 @@ public final class CompChatColor implements TextColor, ConfigStringSerializable 
 		}
 
 		return "reset".equals(tag) || "b".equals(tag) || "bold".equals(tag) || "i".equals(tag) || "italic".equals(tag) || "u".equals(tag) || "underlined".equals(tag) || "st".equals(tag)
-			   || "strikethrough".equals(tag) || "obf".equals(tag) || "obfuscated".equals(tag) || NamedTextColor.NAMES.value(tag) != null;
+				|| "strikethrough".equals(tag) || "obf".equals(tag) || "obfuscated".equals(tag) || NamedTextColor.NAMES.value(tag) != null;
 	}
 
 	/**

--- a/foundation-core/src/main/java/org/mineacademy/fo/model/CompChatColor.java
+++ b/foundation-core/src/main/java/org/mineacademy/fo/model/CompChatColor.java
@@ -32,6 +32,14 @@ import net.kyori.adventure.text.format.TextDecoration;
 public final class CompChatColor implements TextColor, ConfigStringSerializable {
 
 	/**
+	 * Patterns to identify domains inside and outside of Mini Tags to prevent converting "legacy color codes" inside links to mini tags
+	 * in convertLegacyToMini() method.
+	 */
+	private static final Pattern DOMAIN_INSIDE_MINI_TAG_PATTERN = Pattern.compile("<.*[a-zA-Z0-9\\-.*]+\\s?(\\.|\\*|dot|\\(dot\\)|-|\\(\\*\\)|;|:|,)\\s?(c(| +)o(| +)m|o(| +)r(| +)g|n(| +)e(| +)t|(?<! )c(| +)z|(?<! )c(| +)o|(?<! )u(| +)k|(?<! )s(| +)k|b(| +)i(| +)z|(?<! )m(| +)o(| +)b(| +)i|(?<! )x(| +)x(| +)x|(?<! )e(| +)u|(?<! )m(| +)e|(?<! )i(| +)o|(?<! )o(| +)n(| +)l(| +)i(| +)n(| +)e|(?<! )x(| +)y(| +)z|(?<! )f(| +)r|(?<! )b(| +)e|(?<! )d(| +)e|(?<! )c(| +)a|(?<! )a(| +)l|(?<! )a(| +)i|(?<! )d(| +)e(| +)v|(?<! )a(| +)p(| +)p|(?<! )i(| +)n|(?<! )i(| +)s|(?<! )g(| +)g|(?<! )t(| +)o|(?<! )p(| +)h|(?<! )n(| +)l|(?<! )i(| +)d|(?<! )i(| +)n(| +)c|(?<! )u(| +)s|(?<! )p(| +)w|(?<! )p(| +)r(| +)o|(?<! )t(| +)v|(?<! )c(| +)x|(?<! )m(| +)x|(?<! )f(| +)m|(?<! )c(| +)c|(?<! )v(| +)i(| +)p|(?<! )f(| +)u(| +)n|(?<! )i(| +)c(| +)u)\\b"),
+			GENERIC_DOMAIN_PATTERN = Pattern.compile("[a-zA-Z0-9\\-.*]+\\s?(\\.|\\*|dot|\\(dot\\)|-|\\(\\*\\)|;|:|,)\\s?(c(| +)o(| +)m|o(| +)r(| +)g|n(| +)e(| +)t|(?<! )c(| +)z|(?<! )c(| +)o|(?<! )u(| +)k|(?<! )s(| +)k|b(| +)i(| +)z|(?<! )m(| +)o(| +)b(| +)i|(?<! )x(| +)x(| +)x|(?<! )e(| +)u|(?<! )m(| +)e|(?<! )i(| +)o|(?<! )o(| +)n(| +)l(| +)i(| +)n(| +)e|(?<! )x(| +)y(| +)z|(?<! )f(| +)r|(?<! )b(| +)e|(?<! )d(| +)e|(?<! )c(| +)a|(?<! )a(| +)l|(?<! )a(| +)i|(?<! )d(| +)e(| +)v|(?<! )a(| +)p(| +)p|(?<! )i(| +)n|(?<! )i(| +)s|(?<! )g(| +)g|(?<! )t(| +)o|(?<! )p(| +)h|(?<! )n(| +)l|(?<! )i(| +)d|(?<! )i(| +)n(| +)c|(?<! )u(| +)s|(?<! )p(| +)w|(?<! )p(| +)r(| +)o|(?<! )t(| +)v|(?<! )c(| +)x|(?<! )m(| +)x|(?<! )f(| +)m|(?<! )c(| +)c|(?<! )v(| +)i(| +)p|(?<! )f(| +)u(| +)n|(?<! )i(| +)c(| +)u)\\b"),
+			COLOR_CODE_PATTERN = Pattern.compile("(?i)(?:[§&][0-9a-fk-or])+");
+
+	/**
 	 * The special character which prefixes all chat colour codes. Use this if
 	 * you need to dynamically convert colour codes from your custom format.
 	 */
@@ -826,41 +834,60 @@ public final class CompChatColor implements TextColor, ConfigStringSerializable 
 	public static String convertLegacyToMini(final String message, final boolean supportAmpersand) {
 		final StringBuilder result = new StringBuilder();
 
-		final Pattern DOMAIN_INSIDE_MINI_TAG_PATTERN = Pattern.compile("<.*[a-zA-Z0-9\\-.*]+\\s?(\\.|\\*|dot|\\(dot\\)|-|\\(\\*\\)|;|:|,)\\s?(c(| +)o(| +)m|o(| +)r(| +)g|n(| +)e(| +)t|(?<! )c(| +)z|(?<! )c(| +)o|(?<! )u(| +)k|(?<! )s(| +)k|b(| +)i(| +)z|(?<! )m(| +)o(| +)b(| +)i|(?<! )x(| +)x(| +)x|(?<! )e(| +)u|(?<! )m(| +)e|(?<! )i(| +)o|(?<! )o(| +)n(| +)l(| +)i(| +)n(| +)e|(?<! )x(| +)y(| +)z|(?<! )f(| +)r|(?<! )b(| +)e|(?<! )d(| +)e|(?<! )c(| +)a|(?<! )a(| +)l|(?<! )a(| +)i|(?<! )d(| +)e(| +)v|(?<! )a(| +)p(| +)p|(?<! )i(| +)n|(?<! )i(| +)s|(?<! )g(| +)g|(?<! )t(| +)o|(?<! )p(| +)h|(?<! )n(| +)l|(?<! )i(| +)d|(?<! )i(| +)n(| +)c|(?<! )u(| +)s|(?<! )p(| +)w|(?<! )p(| +)r(| +)o|(?<! )t(| +)v|(?<! )c(| +)x|(?<! )m(| +)x|(?<! )f(| +)m|(?<! )c(| +)c|(?<! )v(| +)i(| +)p|(?<! )f(| +)u(| +)n|(?<! )i(| +)c(| +)u)\\b"),
-				GENERIC_DOMAIN_PATTERN = Pattern.compile("[a-zA-Z0-9\\-.*]+\\s?(\\.|\\*|dot|\\(dot\\)|-|\\(\\*\\)|;|:|,)\\s?(c(| +)o(| +)m|o(| +)r(| +)g|n(| +)e(| +)t|(?<! )c(| +)z|(?<! )c(| +)o|(?<! )u(| +)k|(?<! )s(| +)k|b(| +)i(| +)z|(?<! )m(| +)o(| +)b(| +)i|(?<! )x(| +)x(| +)x|(?<! )e(| +)u|(?<! )m(| +)e|(?<! )i(| +)o|(?<! )o(| +)n(| +)l(| +)i(| +)n(| +)e|(?<! )x(| +)y(| +)z|(?<! )f(| +)r|(?<! )b(| +)e|(?<! )d(| +)e|(?<! )c(| +)a|(?<! )a(| +)l|(?<! )a(| +)i|(?<! )d(| +)e(| +)v|(?<! )a(| +)p(| +)p|(?<! )i(| +)n|(?<! )i(| +)s|(?<! )g(| +)g|(?<! )t(| +)o|(?<! )p(| +)h|(?<! )n(| +)l|(?<! )i(| +)d|(?<! )i(| +)n(| +)c|(?<! )u(| +)s|(?<! )p(| +)w|(?<! )p(| +)r(| +)o|(?<! )t(| +)v|(?<! )c(| +)x|(?<! )m(| +)x|(?<! )f(| +)m|(?<! )c(| +)c|(?<! )v(| +)i(| +)p|(?<! )f(| +)u(| +)n|(?<! )i(| +)c(| +)u)\\b"),
-				COLOR_CODE_PATTERN = Pattern.compile("(?i)(?:[§&][0-9a-fk-or])+");
+		// Split the message by spaces so we can ignore domains
+		final String[] parts = message.split(" ", -1);
 
-		for (int idx = 0; idx < message.split(" ", -1).length; idx++) {
-			String part = message.split(" ", -1)[idx];
+		for (int idx = 0; idx < parts.length; idx++) {
+			final String part = parts[idx];
 
-			// If it's empty, that means it was an extra space
-			if (part.isEmpty()) {
-				result.append(" ");
+			if (DOMAIN_INSIDE_MINI_TAG_PATTERN.matcher(part).find()) {
+				// Domain inside <click_url> tag, should be ignored
+				result.append(part);
+				if (idx < parts.length - 1) result.append(' ');
 				continue;
 			}
 
-			if(DOMAIN_INSIDE_MINI_TAG_PATTERN.matcher(part).find()) {
-				result.append(part).append(" ");
-				continue;
+			if (GENERIC_DOMAIN_PATTERN.matcher(part).find()) {
+				// Actual domain in the player message, should be sanitized and colors should be ignored
 
-			} else if(GENERIC_DOMAIN_PATTERN.matcher(part).find()) {
-				if(String.valueOf(part.charAt(0)).matches("[§&]")) {
+				if (!part.isEmpty() && (part.charAt(0) == '§' || part.charAt(0) == '&')) {
 
+					// Domain has a color code at the start, so we need to color it properly :)
 					final Matcher matcher = COLOR_CODE_PATTERN.matcher(part);
-					String color = null;
+					String lastMatch = null;
+					String startingMatch = null;
 
-					while(matcher.find() && (color == null || !part.startsWith(color))) {
-						color = matcher.group();
+					while (matcher.find()) {
+						String g = matcher.group();
+						if (part.startsWith(g)) {
+							startingMatch = g;
+							break;
+						}
+						lastMatch = g;
 					}
 
-					if(color != null)
-						result.append(CompChatColor.convertLegacyToMini(color, true)).append(part.replaceFirst(color, "")).append(" ");
+					final String color = (startingMatch != null) ? startingMatch : lastMatch;
 
-				} else result.append(part).append(" ");
+					if (color != null) {
+
+						// Link colorized, now we add the rest of it without parsing colors
+						result.append(CompChatColor.convertLegacyToMini(color, true))
+								.append(part.replaceFirst(Pattern.quote(color), ""));
+						if (idx < parts.length - 1) result.append(' ');
+						continue;
+					}
+				} else {
+
+					// Domain has no color code, just append it without parsing colors
+					result.append(part);
+					if (idx < parts.length - 1) result.append(' ');
+					continue;
+				}
 
 				continue;
 			}
 
+			// Untouched original code below since no domains were identified in this part
 			for (int i = 0; i < part.length(); i++) {
 
 				// Support §x§R§R§G§G§B§B hex colors
@@ -901,10 +928,9 @@ public final class CompChatColor implements TextColor, ConfigStringSerializable 
 				result.append(part.charAt(i));
 			}
 
-			// re-append the space except after the last part
-			if (idx < message.split(" ", -1).length - 1) {
+			// Re-append the space we used to split if it is not the last part
+			if (idx < parts.length - 1)
 				result.append(" ");
-			}
 		}
 
 		return result.toString();
@@ -1071,7 +1097,7 @@ public final class CompChatColor implements TextColor, ConfigStringSerializable 
 		}
 
 		return "reset".equals(tag) || "b".equals(tag) || "bold".equals(tag) || "i".equals(tag) || "italic".equals(tag) || "u".equals(tag) || "underlined".equals(tag) || "st".equals(tag)
-				|| "strikethrough".equals(tag) || "obf".equals(tag) || "obfuscated".equals(tag) || NamedTextColor.NAMES.value(tag) != null;
+			   || "strikethrough".equals(tag) || "obf".equals(tag) || "obfuscated".equals(tag) || NamedTextColor.NAMES.value(tag) != null;
 	}
 
 	/**


### PR DESCRIPTION
(Related to multiple ChatControl issues)

Because I was splitting the text by spaces, if we had multiple spaces between two words, it would consider one space only.

Implemented proper handling for that case without losing the original fix, for the chat links.

Update:

This method needed a complete overhaul that addresses the issue mentioned above and many others.