### PR TITLE
Update Paper to 1.21.10

### DIFF
--- a/foundation-bukkit/pom.xml
+++ b/foundation-bukkit/pom.xml
@@ -27,7 +27,7 @@
 		<dependency>
 			<groupId>io.papermc.paper</groupId>
 			<artifactId>paper-api</artifactId>
-			<version>1.21.9-R0.1-SNAPSHOT</version>
+			<version>1.21.10-R0.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mineacademy</groupId>
@@ -51,6 +51,12 @@
 			<artifactId>adventure-platform-bukkit</artifactId>
 			<version>4.4.1</version>
 			<scope>provided</scope>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/net.kyori/adventure-api -->
+		<dependency>
+			<groupId>net.kyori</groupId>
+			<artifactId>adventure-api</artifactId>
+			<version>4.25.0</version>
 		</dependency>
 
 		<!-- Only needed for NBT-API -->

--- a/foundation-bukkit/src/main/java/org/mineacademy/fo/EntityUtil.java
+++ b/foundation-bukkit/src/main/java/org/mineacademy/fo/EntityUtil.java
@@ -140,7 +140,7 @@ public final class EntityUtil {
 				boolean found = false;
 
 				for (final World other : Bukkit.getWorlds())
-					if (type.isEnabledByFeature(other)) {
+					if (other.isEnabled(type)) {
 						world = other;
 
 						found = true;

--- a/foundation-bukkit/src/main/java/org/mineacademy/fo/remain/CompEntityType.java
+++ b/foundation-bukkit/src/main/java/org/mineacademy/fo/remain/CompEntityType.java
@@ -231,7 +231,7 @@ public final class CompEntityType {
 
 			try {
 				for (final World other : Bukkit.getWorlds())
-					if (type.isEnabledByFeature(other)) {
+					if (other.isEnabled(type)) {
 						enabledByFeature = true;
 
 						break;


### PR DESCRIPTION
It was necessary to add the `adventure-api` dependency since there was a compilation error right after updating to Paper 1.21.10 about an unaccessible adventure class. This was the only solution. I'll keep it updated though.