### PR TITLE
Fix RowDate constructor to use provided date parameter

### DIFF
--- a/foundation-core/src/main/java/org/mineacademy/fo/database/RowDate.java
+++ b/foundation-core/src/main/java/org/mineacademy/fo/database/RowDate.java
@@ -28,7 +28,7 @@ public abstract class RowDate extends Row {
 	 * @param date
 	 */
 	protected RowDate(final long date) {
-		this.date = System.currentTimeMillis();
+		this.date = date;
 	}
 
 	/**


### PR DESCRIPTION
Possible fix to [this issue](https://github.com/kangarko/ChatControl/issues/3380)